### PR TITLE
Added memory limits to Rodeo and ThreadedRodeo

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,13 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+
+### Added
+
+- Added the `MemoryLimits` struct for creating memory limits on interners
+- Gave `Rodeo` & `ThreadedRodeo` the ability to be given a hard memory capacity, currently only limiting the amount of memory allocated within the arena it uses
+- Added the `set_memory_limits`, `with_memory_limits`, `with_capacity_and_memory_limits` and `with_capacity_memory_limits_and_hasher` methods to `Rodeo` & `ThreadedRodeo`
+
+### Changed
+
+- Debug views of all interners now show their arenas
+
 ## [0.3.1] - 2020-07-24
 
-## Added
+### Added
 
 - Added the `get_or_intern_static` and `try_get_or_intern_static` methods to `ThreadedRodeo` (Thanks to [@jonas-schievink](https://github.com/Kixiron/lasso/pull/6))
 
-## Fixed
+### Fixed
 
 - [Strange double-internment bug](https://github.com/Kixiron/lasso/issues/7)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the `MemoryLimits` struct for creating memory limits on interners
 - Gave `Rodeo` & `ThreadedRodeo` the ability to be given a hard memory capacity, currently only limiting the amount of memory allocated within the arena it uses
-- Added the `set_memory_limits`, `with_memory_limits`, `with_capacity_and_memory_limits` and `with_capacity_memory_limits_and_hasher` methods to `Rodeo` & `ThreadedRodeo`
+- Added the `with_memory_limits`, `with_capacity_and_memory_limits` and `with_capacity_memory_limits_and_hasher` methods to `Rodeo` & `ThreadedRodeo` for creating interners with memory limits
+- Added `set_memory_limits` to `Rodeo` & `ThreadedRodeo` for in-flight modification of memory limits
+- Added `current_memory_usage` and `max_memory_usage` methods to `Rodeo` & `ThreadedRodeo` for introspection of current memory usage maximum memory usage
 
 ### Changed
 

--- a/release.toml
+++ b/release.toml
@@ -2,10 +2,33 @@ pre-release-commit-message = "Release v{{version}}"
 no-dev-version = true
 tag-message = "v{{version}}"
 tag-name = "v{{version}}"
-pre-release-replacements = [
-    { file="Changelog.md", search="Unreleased",           replace="{{version}}" },
-    { file="Changelog.md", search="\\.\\.\\.HEAD",        replace="...{{tag_name}}" },
-    { file="Changelog.md", search="ReleaseDate",          replace="{{date}}" },
-    { file="Changelog.md", search="<!-- next-header -->", replace="<!-- next-header -->\n## [Unreleased] - ReleaseDate" },
-    { file="Changelog.md", search="<!-- next-url -->",    replace="<!-- next-url -->\n[Unreleased]: https://github.com/Kixiron/lasso/compare/{{tag_name}}...HEAD" },
-]
+
+[[pre-release-replacements]]
+file = "Changelog.md"
+search = "Unreleased"
+replace = "{{version}}"
+
+[[pre-release-replacements]]
+file = "Changelog.md"
+search = "Unreleased"
+replace = "{{version}}"
+
+[[pre-release-replacements]]
+file = "Changelog.md"
+search = "\\.\\.\\.HEAD"
+replace = "...{{tag_name}}"
+
+[[pre-release-replacements]]
+file = "Changelog.md"
+search = "ReleaseDate"
+replace = "{{date}}"
+
+[[pre-release-replacements]]
+file = "Changelog.md"
+search = "<!-- next-header -->"
+replace = "<!-- next-header -->\n## [Unreleased] - ReleaseDate\n"
+
+[[pre-release-replacements]]
+file = "Changelog.md"
+search = "<!-- next-url -->"
+replace = "<!-- next-url -->\n[Unreleased]: https://github.com/Kixiron/lasso/compare/{{tag_name}}...HEAD"

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -48,7 +48,7 @@ impl Arena {
         if self.memory_usage + requested_mem > self.max_memory_usage {
             None
         } else {
-            self.memory_usage = self.memory_usage + requested_mem;
+            self.memory_usage += requested_mem;
 
             Some(())
         }

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -41,6 +41,10 @@ impl Arena {
         }
     }
 
+    pub(crate) fn memory_usage(&self) -> usize {
+        self.memory_usage
+    }
+
     /// Doesn't actually allocate anything, but increments `self.memory_usage` and returns `None` if
     /// the attempted amount surpasses `max_memory_usage`
     // TODO: Make this return a `Result`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ pub use key::{Key, LargeSpur, MicroSpur, MiniSpur, Spur};
 pub use reader::RodeoReader;
 pub use resolver::RodeoResolver;
 pub use single_threaded::Rodeo;
-pub use util::{Capacity, Iter, Strings};
+pub use util::{Capacity, Iter, MemoryLimits, Strings};
 
 compile! {
     if #[feature = "no-std"] {

--- a/src/multi_threaded.rs
+++ b/src/multi_threaded.rs
@@ -535,6 +535,18 @@ where
         self.arena.lock().unwrap().max_memory_usage = memory_limits.max_memory_usage;
     }
 
+    /// Get the `ThreadedRodeo`'s currently allocated memory
+    #[inline]
+    pub fn current_memory_usage(&self) -> usize {
+        self.arena.lock().unwrap().memory_usage()
+    }
+
+    /// Get the `ThreadedRodeo`'s current maximum of allocated memory
+    #[inline]
+    pub fn max_memory_usage(&self) -> usize {
+        self.arena.lock().unwrap().max_memory_usage
+    }
+
     /// Consumes the current ThreadedRodeo, returning a [`RodeoReader`] to allow contention-free access of the interner
     /// from multiple threads
     ///
@@ -1189,5 +1201,18 @@ mod tests {
 
         assert_eq!(rodeo.resolve(&string1), "0123456789");
         assert_eq!(rodeo.resolve(&string2), "9876543210");
+    }
+
+    #[test]
+    fn memory_usage_stats() {
+        let rodeo: ThreadedRodeo<Spur> = ThreadedRodeo::with_capacity_and_memory_limits(
+            Capacity::for_bytes(NonZeroUsize::new(10).unwrap()),
+            MemoryLimits::for_memory_usage(10),
+        );
+
+        rodeo.get_or_intern("0123456789");
+
+        assert_eq!(rodeo.current_memory_usage(), 10);
+        assert_eq!(rodeo.max_memory_usage(), 10);
     }
 }

--- a/src/multi_threaded.rs
+++ b/src/multi_threaded.rs
@@ -4,7 +4,7 @@ use crate::{
     key::{Key, Spur},
     reader::RodeoReader,
     resolver::RodeoResolver,
-    Capacity,
+    Capacity, MemoryLimits,
 };
 use core::{
     fmt::{Debug, Formatter, Result as FmtResult},
@@ -85,7 +85,11 @@ where
     ///
     #[inline]
     pub fn new() -> Self {
-        Self::with_capacity_and_hasher(Capacity::default(), RandomState::new())
+        Self::with_capacity_memory_limits_and_hasher(
+            Capacity::default(),
+            MemoryLimits::default(),
+            RandomState::new(),
+        )
     }
 
     /// Create a new ThreadedRodeo with the specified capacity. The interner will be able to hold `capacity`
@@ -104,7 +108,65 @@ where
     /// [`Capacity`]: crate::Capacity
     #[inline]
     pub fn with_capacity(capacity: Capacity) -> Self {
-        Self::with_capacity_and_hasher(capacity, RandomState::new())
+        Self::with_capacity_memory_limits_and_hasher(
+            capacity,
+            MemoryLimits::default(),
+            RandomState::new(),
+        )
+    }
+
+    /// Create a new ThreadedRodeo with the specified memory limits. The interner will be able to hold `max_memory_usage`
+    /// bytes of interned strings until it will start returning `None` from `try_get_or_intern` or panicking from
+    /// `get_or_intern`.
+    ///
+    /// Note: If the capacity of the interner is greater than the memory limit, then that will be the effective maximum
+    /// for allocated memory
+    ///
+    /// See [`MemoryLimits`] for more information
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use lasso::{ThreadedRodeo, MemoryLimits, Spur};
+    ///
+    /// let rodeo: ThreadedRodeo<Spur> = ThreadedRodeo::with_memory_limits(MemoryLimits::for_memory_usage(4096));
+    /// ```
+    ///
+    /// [`MemoryLimits`]: crate::MemoryLimits
+    #[inline]
+    pub fn with_memory_limits(memory_limits: MemoryLimits) -> Self {
+        Self::with_capacity_memory_limits_and_hasher(
+            Capacity::default(),
+            memory_limits,
+            RandomState::new(),
+        )
+    }
+
+    /// Create a new ThreadedRodeo with the specified capacity and memory limits. The interner will be able to hold `max_memory_usage`
+    /// bytes of interned strings until it will start returning `None` from `try_get_or_intern` or panicking from
+    /// `get_or_intern`.
+    ///
+    /// Note: If the capacity of the interner is greater than the memory limit, then that will be the effective maximum
+    /// for allocated memory
+    ///
+    /// See [`Capacity`] [`MemoryLimits`] for more information
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use lasso::{ThreadedRodeo, MemoryLimits, Spur};
+    ///
+    /// let rodeo: ThreadedRodeo<Spur> = ThreadedRodeo::with_memory_limits(MemoryLimits::for_memory_usage(4096));
+    /// ```
+    ///
+    /// [`Capacity`]: crate::Capacity
+    /// [`MemoryLimits`]: crate::MemoryLimits
+    #[inline]
+    pub fn with_capacity_and_memory_limits(
+        capacity: Capacity,
+        memory_limits: MemoryLimits,
+    ) -> Self {
+        Self::with_capacity_memory_limits_and_hasher(capacity, memory_limits, RandomState::new())
     }
 }
 
@@ -126,7 +188,11 @@ where
     ///
     #[inline]
     pub fn with_hasher(hash_builder: S) -> Self {
-        Self::with_capacity_and_hasher(Capacity::default(), hash_builder)
+        Self::with_capacity_memory_limits_and_hasher(
+            Capacity::default(),
+            MemoryLimits::default(),
+            hash_builder,
+        )
     }
 
     /// Creates a new ThreadedRodeo with the specified capacity that will use the given hasher for its internal hashmap
@@ -145,13 +211,46 @@ where
     /// [`Capacity`]: crate::Capacity
     #[inline]
     pub fn with_capacity_and_hasher(capacity: Capacity, hash_builder: S) -> Self {
+        Self::with_capacity_memory_limits_and_hasher(
+            capacity,
+            MemoryLimits::default(),
+            hash_builder,
+        )
+    }
+
+    /// Creates a new ThreadedRodeo with the specified capacity and memory limits that will use the given hasher for its internal hashmap
+    ///
+    /// See [`Capacity`] and [`MemoryLimits`] for more information
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use lasso::{Spur, Capacity, MemoryLimits, ThreadedRodeo};
+    /// use std::collections::hash_map::RandomState;
+    ///
+    /// let rodeo: ThreadedRodeo<Spur, RandomState> = ThreadedRodeo::with_capacity_memory_limits_and_hasher(
+    ///     Capacity::for_strings(10),
+    ///     MemoryLimits::for_memory_usage(4096),
+    ///     RandomState::new(),
+    /// );
+    /// ```
+    ///
+    /// [`Capacity`]: crate::Capacity
+    /// [`MemoryLimits`]: crate::MemoryLimits
+    #[inline]
+    pub fn with_capacity_memory_limits_and_hasher(
+        capacity: Capacity,
+        memory_limits: MemoryLimits,
+        hash_builder: S,
+    ) -> Self {
         let Capacity { strings, bytes } = capacity;
+        let MemoryLimits { max_memory_usage } = memory_limits;
 
         Self {
             map: DashMap::with_capacity_and_hasher(strings, hash_builder.clone()),
             strings: DashMap::with_capacity_and_hasher(strings, hash_builder),
             key: AtomicUsize::new(0),
-            arena: Mutex::new(Arena::with_capacity(bytes)),
+            arena: Mutex::new(Arena::new(bytes, max_memory_usage)),
         }
     }
 
@@ -226,7 +325,7 @@ where
 
             // Safety: The drop impl removes all references before the arena is dropped
             let string: &'static str =
-                unsafe { self.arena.lock().unwrap().store_str(string_slice) };
+                unsafe { self.arena.lock().unwrap().store_str(string_slice)? };
             let key = K::try_from_usize(self.key.fetch_add(1, Ordering::SeqCst))?;
 
             self.map.insert(string, key);
@@ -427,6 +526,15 @@ where
         self.strings.capacity()
     }
 
+    /// Set the `ThreadedRodeo`'s maximum memory usage while in-flight
+    ///
+    /// Note that setting the maximum memory usage to below the currently allocated
+    /// memory will do nothing
+    #[inline]
+    pub fn set_memory_limits(&self, memory_limits: MemoryLimits) {
+        self.arena.lock().unwrap().max_memory_usage = memory_limits.max_memory_usage;
+    }
+
     /// Consumes the current ThreadedRodeo, returning a [`RodeoReader`] to allow contention-free access of the interner
     /// from multiple threads
     ///
@@ -595,6 +703,7 @@ where
         f.debug_struct("Rodeo")
             .field("map", &self.map)
             .field("strings", &self.strings)
+            .field("arena", &self.arena)
             .finish()
     }
 }
@@ -605,7 +714,8 @@ unsafe impl<K: Send, S: Send> Send for ThreadedRodeo<K, S> {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{hasher::RandomState, MicroSpur};
+    use crate::{hasher::RandomState, Capacity, MemoryLimits, MicroSpur};
+    use core::num::NonZeroUsize;
 
     #[cfg(not(any(miri, feature = "no-std")))]
     use std::{sync::Arc, thread};
@@ -965,5 +1075,119 @@ mod tests {
 
         let reader = rodeo.into_reader();
         assert_eq!("A", reader.resolve(&key));
+    }
+
+    #[test]
+    fn memory_exhausted() {
+        let rodeo: ThreadedRodeo<Spur> = ThreadedRodeo::with_capacity_and_memory_limits(
+            Capacity::for_bytes(NonZeroUsize::new(10).unwrap()),
+            MemoryLimits::for_memory_usage(10),
+        );
+
+        let string = rodeo.try_get_or_intern("0123456789").unwrap();
+        assert_eq!(rodeo.resolve(&string), "0123456789");
+
+        assert!(rodeo.try_get_or_intern("").is_none());
+        assert!(rodeo.try_get_or_intern("").is_none());
+        assert!(rodeo.try_get_or_intern("").is_none());
+
+        assert_eq!(rodeo.resolve(&string), "0123456789");
+    }
+
+    #[test]
+    #[cfg(not(any(miri, feature = "no-std")))]
+    fn memory_exhausted_threaded() {
+        let rodeo: Arc<ThreadedRodeo<Spur>> =
+            Arc::new(ThreadedRodeo::with_capacity_and_memory_limits(
+                Capacity::for_bytes(NonZeroUsize::new(10).unwrap()),
+                MemoryLimits::for_memory_usage(10),
+            ));
+
+        let moved = Arc::clone(&rodeo);
+        thread::spawn(move || {
+            let string = moved.try_get_or_intern("0123456789").unwrap();
+            assert_eq!(moved.resolve(&string), "0123456789");
+
+            assert!(moved.try_get_or_intern("").is_none());
+            assert!(moved.try_get_or_intern("").is_none());
+            assert!(moved.try_get_or_intern("").is_none());
+
+            assert_eq!(moved.resolve(&string), "0123456789");
+        });
+
+        let string = rodeo.try_get_or_intern("0123456789").unwrap();
+        assert_eq!(rodeo.resolve(&string), "0123456789");
+
+        assert!(rodeo.try_get_or_intern("").is_none());
+        assert!(rodeo.try_get_or_intern("").is_none());
+        assert!(rodeo.try_get_or_intern("").is_none());
+
+        assert_eq!(rodeo.resolve(&string), "0123456789");
+    }
+
+    // TODO: Add a reason for should_panic once `Result`s are used
+    #[test]
+    #[should_panic]
+    fn memory_exhausted_panics() {
+        let rodeo: ThreadedRodeo<Spur> = ThreadedRodeo::with_capacity_and_memory_limits(
+            Capacity::for_bytes(NonZeroUsize::new(10).unwrap()),
+            MemoryLimits::for_memory_usage(10),
+        );
+
+        let string = rodeo.get_or_intern("0123456789");
+        assert_eq!(rodeo.resolve(&string), "0123456789");
+
+        rodeo.get_or_intern("");
+    }
+
+    #[test]
+    fn with_capacity_memory_limits_and_hasher() {
+        let rodeo: ThreadedRodeo<Spur, RandomState> =
+            ThreadedRodeo::with_capacity_memory_limits_and_hasher(
+                Capacity::default(),
+                MemoryLimits::default(),
+                RandomState::new(),
+            );
+
+        rodeo.get_or_intern("Test");
+    }
+
+    #[test]
+    fn with_capacity_and_memory_limits() {
+        let rodeo: ThreadedRodeo<Spur> = ThreadedRodeo::with_capacity_and_memory_limits(
+            Capacity::default(),
+            MemoryLimits::default(),
+        );
+
+        rodeo.get_or_intern("Test");
+    }
+
+    #[test]
+    fn set_memory_limits() {
+        let rodeo: ThreadedRodeo<Spur> = ThreadedRodeo::with_capacity_and_memory_limits(
+            Capacity::for_bytes(NonZeroUsize::new(10).unwrap()),
+            MemoryLimits::for_memory_usage(10),
+        );
+
+        let string1 = rodeo.try_get_or_intern("0123456789").unwrap();
+        assert_eq!(rodeo.resolve(&string1), "0123456789");
+
+        assert!(rodeo.try_get_or_intern("").is_none());
+        assert!(rodeo.try_get_or_intern("").is_none());
+        assert!(rodeo.try_get_or_intern("").is_none());
+
+        assert_eq!(rodeo.resolve(&string1), "0123456789");
+
+        rodeo.set_memory_limits(MemoryLimits::for_memory_usage(20));
+
+        let string2 = rodeo.try_get_or_intern("9876543210").unwrap();
+        assert_eq!(rodeo.resolve(&string2), "9876543210");
+
+        assert!(rodeo.try_get_or_intern("").is_none());
+        assert!(rodeo.try_get_or_intern("").is_none());
+        assert!(rodeo.try_get_or_intern("").is_none());
+
+        assert_eq!(rodeo.resolve(&string1), "0123456789");
+        assert_eq!(rodeo.resolve(&string2), "9876543210");
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5,10 +5,7 @@ use crate::{
     resolver::RodeoResolver,
     util::{Iter, Strings},
 };
-use core::{
-    fmt::{Debug, Formatter, Result as FmtResult},
-    hash::{BuildHasher, Hash, Hasher},
-};
+use core::hash::{BuildHasher, Hash, Hasher};
 use hashbrown::HashMap;
 
 compile! {
@@ -25,6 +22,7 @@ compile! {
 ///
 /// [`Rodeo`]: crate::Rodeo
 /// [`ThreadedRodeo`]: crate::ThreadedRodeo
+#[derive(Debug)]
 pub struct RodeoReader<K = Spur, S = RandomState> {
     // The logic behind this arrangement is more heavily documented inside of
     // `Rodeo` itself
@@ -283,16 +281,6 @@ impl<K, S> RodeoReader<K, S> {
         // Safety: The current reader no longer contains references to the strings
         // in the vec given to RodeoResolver
         unsafe { RodeoResolver::new(strings, arena) }
-    }
-}
-
-impl<K: Debug, S> Debug for RodeoReader<K, S> {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.debug_struct("Rodeo")
-            .field("map", &self.map)
-            .field("strings", &self.strings)
-            .finish()
     }
 }
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -3,10 +3,7 @@ use crate::{
     key::{Key, Spur},
     util::{Iter, Strings},
 };
-use core::{
-    fmt::{Debug, Formatter, Result as FmtResult},
-    marker::PhantomData,
-};
+use core::marker::PhantomData;
 
 compile! {
     if #[feature = "no-std"] {
@@ -21,6 +18,7 @@ compile! {
 ///
 /// [`Rodeo`]: crate::Rodeo
 /// [`ThreadedRodeo`]: crate::ThreadedRodeo
+#[derive(Debug)]
 pub struct RodeoResolver<K = Spur> {
     /// Vector of strings mapped to key indexes that allows key to string resolution
     pub(crate) strings: Vec<&'static str>,
@@ -200,15 +198,6 @@ impl<K> RodeoResolver<K> {
     #[inline]
     pub fn strings(&self) -> Strings<'_, K> {
         Strings::from_resolver(self)
-    }
-}
-
-impl<K: Debug> Debug for RodeoResolver<K> {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.debug_struct("RodeoResolver")
-            .field("strings", &self.strings)
-            .finish()
     }
 }
 

--- a/src/single_threaded.rs
+++ b/src/single_threaded.rs
@@ -658,6 +658,18 @@ where
     pub fn set_memory_limits(&mut self, memory_limits: MemoryLimits) {
         self.arena.max_memory_usage = memory_limits.max_memory_usage;
     }
+
+    /// Get the `Rodeo`'s currently allocated memory
+    #[inline]
+    pub fn current_memory_usage(&self) -> usize {
+        self.arena.memory_usage()
+    }
+
+    /// Get the `Rodeo`'s current maximum of allocated memory
+    #[inline]
+    pub fn max_memory_usage(&self) -> usize {
+        self.arena.max_memory_usage
+    }
 }
 
 impl<K, S> Rodeo<K, S>
@@ -1155,5 +1167,18 @@ mod tests {
 
         assert_eq!(rodeo.resolve(&string1), "0123456789");
         assert_eq!(rodeo.resolve(&string2), "9876543210");
+    }
+
+    #[test]
+    fn memory_usage_stats() {
+        let mut rodeo: Rodeo<Spur> = Rodeo::with_capacity_and_memory_limits(
+            Capacity::for_bytes(NonZeroUsize::new(10).unwrap()),
+            MemoryLimits::for_memory_usage(10),
+        );
+
+        rodeo.get_or_intern("0123456789");
+
+        assert_eq!(rodeo.current_memory_usage(), 10);
+        assert_eq!(rodeo.max_memory_usage(), 10);
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -90,10 +90,7 @@ impl MemoryLimits {
     /// Create a new `MemoryLimits` with the number of bytes that the interner can allocate
     #[inline]
     pub fn for_memory_usage(max_memory_usage: usize) -> Self {
-        Self {
-            max_memory_usage,
-            ..Self::default()
-        }
+        Self { max_memory_usage }
     }
 
     /// Returns the maximum memory usage this `MemoryLimits` can allocate

--- a/src/util.rs
+++ b/src/util.rs
@@ -71,6 +71,48 @@ impl Default for Capacity {
     }
 }
 
+/// Settings for the memory consumption of an interner
+///
+/// By default `max_memory_usage` is set to `usize::MAX`
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MemoryLimits {
+    /// The maximum memory an interner will allocate
+    pub(crate) max_memory_usage: usize,
+}
+
+impl MemoryLimits {
+    /// Create a new `MemoryLimits` with the number of bytes that the interner can allocate
+    #[inline]
+    pub fn new(max_memory_usage: usize) -> Self {
+        Self { max_memory_usage }
+    }
+
+    /// Create a new `MemoryLimits` with the number of bytes that the interner can allocate
+    #[inline]
+    pub fn for_memory_usage(max_memory_usage: usize) -> Self {
+        Self {
+            max_memory_usage,
+            ..Self::default()
+        }
+    }
+
+    /// Returns the maximum memory usage this `MemoryLimits` can allocate
+    #[inline]
+    pub fn max_memory_usage(&self) -> usize {
+        self.max_memory_usage
+    }
+}
+
+/// Creates a `MemoryLimits` with `max_memory_usage` set to `usize::max_value()`
+impl Default for MemoryLimits {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            max_memory_usage: usize::max_value(),
+        }
+    }
+}
+
 /// An iterator over an interner's strings and keys
 #[derive(Debug)]
 pub struct Iter<'a, K> {


### PR DESCRIPTION
Adds memory limits to `Rodeo` and `ThreadedRodeo`

As of now, interners just return `None` when their memory limit has been exhausted, but in the future I plan to shift over to `Result`s to give better insight to what the interner's doing.
A number of methods were added, mostly to allow the same construction that capacity and hashers get, but the `set_memory_limits` method was also added which allows in-flight configuration of memory limits
Currently there's no sanity checking either, e.x. setting your capacity to 100 and max memory to 10 will allocate 100 bytes of memory but nothing more. I'm not entirely sure how/when sanity checking should be done, of if it's even useful

cc @Evrey