### PR TITLE
impl Index<Key> for Rodeo types

### DIFF
--- a/src/multi_threaded.rs
+++ b/src/multi_threaded.rs
@@ -807,8 +807,8 @@ where
 
 impl<K, S> Index<K> for ThreadedRodeo<K, S>
 where
-    K: Key,
-    S: BuildHasher,
+    K: Key + Hash,
+    S: BuildHasher + Clone,
 {
     type Output = str;
 

--- a/src/multi_threaded.rs
+++ b/src/multi_threaded.rs
@@ -11,6 +11,7 @@ use core::{
     hash::{BuildHasher, Hash, Hasher},
     iter::{self, FromIterator},
     mem,
+    ops::Index,
     sync::atomic::{AtomicUsize, Ordering},
 };
 use dashmap::DashMap;
@@ -804,6 +805,19 @@ where
     }
 }
 
+impl<K, S> Index<K> for ThreadedRodeo<K, S>
+where
+    K: Key,
+    S: BuildHasher,
+{
+    type Output = str;
+
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn index(&self, idx: K) -> &Self::Output {
+        self.resolve(&idx)
+    }
+}
+
 impl<K, S, T> Extend<T> for ThreadedRodeo<K, S>
 where
     K: Key + Hash,
@@ -1505,6 +1519,14 @@ mod tests {
         assert!(rodeo.contains("c"));
         assert!(rodeo.contains("d"));
         assert!(rodeo.contains("e"));
+    }
+
+    #[test]
+    fn index() {
+        let rodeo = ThreadedRodeo::default();
+        let key = rodeo.get_or_intern("A");
+
+        assert_eq!("A", &rodeo[key]);
     }
 
     #[test]

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -4,7 +4,7 @@ use crate::{
     util::{Iter, Strings},
     Rodeo, RodeoReader,
 };
-use core::marker::PhantomData;
+use core::{marker::PhantomData, ops::Index};
 
 compile! {
     if #[feature = "no-std"] {
@@ -240,6 +240,15 @@ impl<'a, K: Key> IntoIterator for &'a RodeoResolver<K> {
     }
 }
 
+impl<K: Key> Index<K> for RodeoResolver<K> {
+    type Output = str;
+
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn index(&self, idx: K) -> &Self::Output {
+        self.resolve(&idx)
+    }
+}
+
 impl<K> Eq for RodeoResolver<K> {}
 
 impl<K> PartialEq<Self> for RodeoResolver<K> {
@@ -461,6 +470,15 @@ mod tests {
                 assert_eq!(key, Spur::try_from_usize(expected_key).unwrap());
                 assert_eq!(string, expected_string);
             }
+        }
+
+        #[test]
+        fn index() {
+            let mut rodeo = Rodeo::default();
+            let key = rodeo.get_or_intern("A");
+
+            let resolver = rodeo.into_resolver();
+            assert_eq!("A", &resolver[key]);
         }
 
         #[test]
@@ -758,6 +776,15 @@ mod tests {
                 assert_eq!(key, Spur::try_from_usize(expected_key).unwrap());
                 assert_eq!(string, expected_string);
             }
+        }
+
+        #[test]
+        fn index() {
+            let rodeo = ThreadedRodeo::default();
+            let key = rodeo.intern("A");
+
+            let resolver = rodeo.into_resolver();
+            assert_eq!("A", &resolver[key]);
         }
 
         #[test]

--- a/src/single_threaded.rs
+++ b/src/single_threaded.rs
@@ -10,6 +10,7 @@ use crate::{
 use core::{
     hash::{BuildHasher, Hash, Hasher},
     iter::FromIterator,
+    ops::Index,
 };
 use hashbrown::{hash_map::RawEntryMut, HashMap};
 
@@ -831,6 +832,19 @@ where
     }
 }
 
+impl<K, S> Index<K> for Rodeo<K, S>
+where
+    K: Key,
+    S: BuildHasher,
+{
+    type Output = str;
+
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn index(&self, idx: K) -> &Self::Output {
+        self.resolve(&idx)
+    }
+}
+
 impl<K, S, T> Extend<T> for Rodeo<K, S>
 where
     K: Key,
@@ -1446,6 +1460,14 @@ mod tests {
         assert!(rodeo.contains("c"));
         assert!(rodeo.contains("d"));
         assert!(rodeo.contains("e"));
+    }
+
+    #[test]
+    fn index() {
+        let mut rodeo = Rodeo::default();
+        let key = rodeo.get_or_intern("A");
+
+        assert_eq!("A", &rodeo[key]);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #10.

Decided to take the key by value for the index, since `Key` requires `Copy` anyways, and this makes it *slightly* more ergonomic.