### PR TITLE
Unseal traits and allow turning interner into any resolver

### DIFF
--- a/src/interface/boxed.rs
+++ b/src/interface/boxed.rs
@@ -1,5 +1,5 @@
 use super::{Interner, Reader, Resolver};
-use crate::{Key, LassoResult, RodeoResolver};
+use crate::{Key, LassoResult};
 #[cfg(feature = "no-std")]
 use alloc::boxed::Box;
 
@@ -64,13 +64,19 @@ where
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_resolver(self) -> RodeoResolver<K> {
+    fn into_resolver(self) -> Box<dyn Resolver<K>>
+    where
+        Self: 'static,
+    {
         I::into_resolver_boxed(self)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_resolver_boxed(self: Box<Self>) -> RodeoResolver<K> {
+    fn into_resolver_boxed(self: Box<Self>) -> Box<dyn Resolver<K>>
+    where
+        Self: 'static,
+    {
         (*self).into_resolver()
     }
 }

--- a/src/interface/rodeo.rs
+++ b/src/interface/rodeo.rs
@@ -1,6 +1,6 @@
 //! Implementations of [`Interner`], [`Reader`] and [`Resolver`] for [`Rodeo`]
 
-use crate::{Interner, Key, LassoResult, Reader, Resolver, Rodeo, RodeoResolver};
+use crate::{Interner, Key, LassoResult, Reader, Resolver, Rodeo};
 #[cfg(feature = "no-std")]
 use alloc::boxed::Box;
 use core::hash::BuildHasher;
@@ -66,14 +66,20 @@ where
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_resolver(self) -> RodeoResolver<K> {
-        self.into_resolver()
+    fn into_resolver(self) -> Box<dyn Resolver<K>>
+    where
+        Self: 'static,
+    {
+        Box::new(self.into_resolver())
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_resolver_boxed(self: Box<Self>) -> RodeoResolver<K> {
-        (*self).into_resolver()
+    fn into_resolver_boxed(self: Box<Self>) -> Box<dyn Resolver<K>>
+    where
+        Self: 'static,
+    {
+        Box::new(Rodeo::into_resolver(*self))
     }
 }
 

--- a/src/interface/rodeo_reader.rs
+++ b/src/interface/rodeo_reader.rs
@@ -1,6 +1,6 @@
 //! Implementations of [`Reader`] and [`Resolver`] for [`RodeoReader`]
 
-use crate::{Key, Reader, Resolver, RodeoReader, RodeoResolver};
+use crate::{Key, Reader, Resolver, RodeoReader};
 #[cfg(feature = "no-std")]
 use alloc::boxed::Box;
 use core::hash::BuildHasher;
@@ -22,14 +22,20 @@ where
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_resolver(self) -> RodeoResolver<K> {
-        self.into_resolver()
+    fn into_resolver(self) -> Box<dyn Resolver<K>>
+    where
+        Self: 'static,
+    {
+        Box::new(self.into_resolver())
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_resolver_boxed(self: Box<Self>) -> RodeoResolver<K> {
-        (*self).into_resolver()
+    fn into_resolver_boxed(self: Box<Self>) -> Box<dyn Resolver<K>>
+    where
+        Self: 'static,
+    {
+        Box::new(RodeoReader::into_resolver(*self))
     }
 }
 

--- a/src/interface/threaded_rodeo.rs
+++ b/src/interface/threaded_rodeo.rs
@@ -1,7 +1,7 @@
 //! Implementations of [`Interner`], [`Reader`] and [`Resolver`] for [`ThreadedRodeo`]
 #![cfg(feature = "multi-threaded")]
 
-use crate::{Interner, Key, LassoResult, Reader, Resolver, RodeoResolver, ThreadedRodeo};
+use crate::{Interner, Key, LassoResult, Reader, Resolver, ThreadedRodeo};
 #[cfg(feature = "no-std")]
 use alloc::boxed::Box;
 use core::hash::{BuildHasher, Hash};
@@ -67,14 +67,20 @@ where
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_resolver(self) -> RodeoResolver<K> {
-        self.into_resolver()
+    fn into_resolver(self) -> Box<dyn Resolver<K>>
+    where
+        Self: 'static,
+    {
+        Box::new(self.into_resolver())
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_resolver_boxed(self: Box<Self>) -> RodeoResolver<K> {
-        (*self).into_resolver()
+    fn into_resolver_boxed(self: Box<Self>) -> Box<dyn Resolver<K>>
+    where
+        Self: 'static,
+    {
+        Box::new(ThreadedRodeo::into_resolver(*self))
     }
 }
 


### PR DESCRIPTION
Note that `into_resolver` no longer returns a `RodeoResolver`, to enable returning both any `Reader` and any `Resolver` impl from the traits.