### PR TITLE
Separate `into_` methods into their own traits and implement `Interner` for `&ThreadedRodeo`

### DIFF
--- a/src/interface/boxed.rs
+++ b/src/interface/boxed.rs
@@ -1,4 +1,4 @@
-use super::{Interner, Reader, Resolver};
+use super::{Interner, IntoReader, IntoResolver, Reader, Resolver};
 use crate::{Key, LassoResult};
 #[cfg(feature = "no-std")]
 use alloc::boxed::Box;
@@ -27,10 +27,18 @@ where
     fn try_get_or_intern_static(&mut self, val: &'static str) -> LassoResult<K> {
         self.try_get_or_intern(val)
     }
+}
+
+impl<K, I> IntoReader<K> for Box<I>
+where
+    K: Key,
+    I: IntoReader<K> + ?Sized + 'static,
+{
+    type Reader = <I as IntoReader<K>>::Reader;
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_reader(self) -> Box<dyn Reader<K>>
+    fn into_reader(self) -> Self::Reader
     where
         Self: 'static,
     {
@@ -39,7 +47,7 @@ where
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_reader_boxed(self: Box<Self>) -> Box<dyn Reader<K>>
+    fn into_reader_boxed(self: Box<Self>) -> Self::Reader
     where
         Self: 'static,
     {
@@ -61,10 +69,18 @@ where
     fn contains(&self, val: &str) -> bool {
         (&**self).contains(val)
     }
+}
+
+impl<K, I> IntoResolver<K> for Box<I>
+where
+    K: Key,
+    I: IntoResolver<K> + ?Sized + 'static,
+{
+    type Resolver = <I as IntoResolver<K>>::Resolver;
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_resolver(self) -> Box<dyn Resolver<K>>
+    fn into_resolver(self) -> Self::Resolver
     where
         Self: 'static,
     {
@@ -73,7 +89,7 @@ where
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_resolver_boxed(self: Box<Self>) -> Box<dyn Resolver<K>>
+    fn into_resolver_boxed(self: Box<Self>) -> Self::Resolver
     where
         Self: 'static,
     {

--- a/src/interface/rodeo.rs
+++ b/src/interface/rodeo.rs
@@ -1,9 +1,10 @@
 //! Implementations of [`Interner`], [`Reader`] and [`Resolver`] for [`Rodeo`]
 
-use crate::{Interner, Key, LassoResult, Reader, Resolver, Rodeo};
+use crate::*;
 #[cfg(feature = "no-std")]
 use alloc::boxed::Box;
 use core::hash::BuildHasher;
+use interface::IntoReaderAndResolver;
 
 impl<K, S> Interner<K> for Rodeo<K, S>
 where
@@ -29,23 +30,38 @@ where
     fn try_get_or_intern_static(&mut self, val: &'static str) -> LassoResult<K> {
         self.try_get_or_intern_static(val)
     }
+}
+
+impl<K, S> IntoReaderAndResolver<K> for Rodeo<K, S>
+where
+    K: Key,
+    S: BuildHasher,
+{
+}
+
+impl<K, S> IntoReader<K> for Rodeo<K, S>
+where
+    K: Key,
+    S: BuildHasher,
+{
+    type Reader = RodeoReader<K, S>;
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_reader(self) -> Box<dyn Reader<K>>
+    fn into_reader(self) -> Self::Reader
     where
         Self: 'static,
     {
-        Box::new(self.into_reader())
+        self.into_reader()
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_reader_boxed(self: Box<Self>) -> Box<dyn Reader<K>>
+    fn into_reader_boxed(self: Box<Self>) -> Self::Reader
     where
         Self: 'static,
     {
-        Box::new(Rodeo::into_reader(*self))
+        Rodeo::into_reader(*self)
     }
 }
 
@@ -63,23 +79,31 @@ where
     fn contains(&self, val: &str) -> bool {
         self.contains(val)
     }
+}
+
+impl<K, S> IntoResolver<K> for Rodeo<K, S>
+where
+    K: Key,
+    S: BuildHasher,
+{
+    type Resolver = RodeoResolver<K>;
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_resolver(self) -> Box<dyn Resolver<K>>
+    fn into_resolver(self) -> Self::Resolver
     where
         Self: 'static,
     {
-        Box::new(self.into_resolver())
+        self.into_resolver()
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_resolver_boxed(self: Box<Self>) -> Box<dyn Resolver<K>>
+    fn into_resolver_boxed(self: Box<Self>) -> Self::Resolver
     where
         Self: 'static,
     {
-        Box::new(Rodeo::into_resolver(*self))
+        Rodeo::into_resolver(*self)
     }
 }
 

--- a/src/interface/rodeo_reader.rs
+++ b/src/interface/rodeo_reader.rs
@@ -1,6 +1,6 @@
 //! Implementations of [`Reader`] and [`Resolver`] for [`RodeoReader`]
 
-use crate::{Key, Reader, Resolver, RodeoReader};
+use crate::{IntoResolver, Key, Reader, Resolver, RodeoReader, RodeoResolver};
 #[cfg(feature = "no-std")]
 use alloc::boxed::Box;
 use core::hash::BuildHasher;
@@ -19,23 +19,31 @@ where
     fn contains(&self, val: &str) -> bool {
         self.contains(val)
     }
+}
+
+impl<K, S> IntoResolver<K> for RodeoReader<K, S>
+where
+    K: Key,
+    S: BuildHasher,
+{
+    type Resolver = RodeoResolver<K>;
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_resolver(self) -> Box<dyn Resolver<K>>
+    fn into_resolver(self) -> Self::Resolver
     where
         Self: 'static,
     {
-        Box::new(self.into_resolver())
+        self.into_resolver()
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_resolver_boxed(self: Box<Self>) -> Box<dyn Resolver<K>>
+    fn into_resolver_boxed(self: Box<Self>) -> Self::Resolver
     where
         Self: 'static,
     {
-        Box::new(RodeoReader::into_resolver(*self))
+        RodeoReader::into_resolver(*self)
     }
 }
 

--- a/src/interface/tests.rs
+++ b/src/interface/tests.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use super::*;
-use crate::{Key, Rodeo, Spur};
+use crate::{Key, Rodeo, RodeoReader, RodeoResolver, Spur};
 
 compile! {
     if #[feature = "multi-threaded"] {
@@ -13,8 +13,9 @@ compile! {
     }
 }
 
-const INTERNED_STRINGS: &[&str] = &["foo", "bar", "baz", "biz", "buzz", "bing"];
-const UNINTERNED_STRINGS: &[&str] = &["rodeo", "default", "string", "static", "unwrap", "array"];
+pub(crate) const INTERNED_STRINGS: &[&str] = &["foo", "bar", "baz", "biz", "buzz", "bing"];
+pub(crate) const UNINTERNED_STRINGS: &[&str] =
+    &["rodeo", "default", "string", "static", "unwrap", "array"];
 
 fn filled_rodeo() -> Rodeo {
     let mut rodeo = Rodeo::default();
@@ -26,7 +27,7 @@ fn filled_rodeo() -> Rodeo {
 }
 
 #[cfg(feature = "multi-threaded")]
-fn filled_threaded_rodeo() -> ThreadedRodeo {
+pub(crate) fn filled_threaded_rodeo() -> ThreadedRodeo {
     let rodeo = ThreadedRodeo::default();
     for string in INTERNED_STRINGS.iter().copied() {
         rodeo.try_get_or_intern_static(string).unwrap();
@@ -38,12 +39,14 @@ fn filled_threaded_rodeo() -> ThreadedRodeo {
 mod interner {
     use super::*;
 
-    pub fn rodeo() -> Box<dyn Interner<Spur>> {
+    pub fn rodeo(
+    ) -> Box<dyn IntoReaderAndResolver<Spur, Reader = RodeoReader, Resolver = RodeoResolver>> {
         Box::new(filled_rodeo())
     }
 
     #[cfg(feature = "multi-threaded")]
-    pub fn threaded_rodeo() -> Box<dyn Interner<Spur>> {
+    pub fn threaded_rodeo(
+    ) -> Box<dyn IntoReaderAndResolver<Spur, Reader = RodeoReader, Resolver = RodeoResolver>> {
         Box::new(filled_threaded_rodeo())
     }
 }
@@ -154,16 +157,16 @@ fn interner_implementations() {
 mod reader {
     use super::*;
 
-    pub fn rodeo() -> Box<dyn Reader<Spur>> {
+    pub fn rodeo() -> Box<dyn IntoResolver<Spur, Resolver = RodeoResolver>> {
         Box::new(filled_rodeo())
     }
 
-    pub fn rodeo_reader() -> Box<dyn Reader<Spur>> {
+    pub fn rodeo_reader() -> Box<dyn IntoResolver<Spur, Resolver = RodeoResolver>> {
         Box::new(filled_rodeo().into_reader())
     }
 
     #[cfg(feature = "multi-threaded")]
-    pub fn threaded_rodeo() -> Box<dyn Reader<Spur>> {
+    pub fn threaded_rodeo() -> Box<dyn IntoResolver<Spur, Resolver = RodeoResolver>> {
         Box::new(filled_threaded_rodeo())
     }
 }

--- a/src/interface/threaded_ref.rs
+++ b/src/interface/threaded_ref.rs
@@ -1,0 +1,139 @@
+#![cfg(feature = "multi-threaded")]
+
+use crate::{Interner, Key, Reader, Resolver, ThreadedRodeo};
+use std::hash::{BuildHasher, Hash};
+
+impl<K, S> Interner<K> for &ThreadedRodeo<K, S>
+where
+    K: Key + Hash,
+    S: BuildHasher + Clone,
+{
+    fn get_or_intern(&mut self, val: &str) -> K {
+        ThreadedRodeo::get_or_intern(self, val)
+    }
+
+    fn try_get_or_intern(&mut self, val: &str) -> crate::LassoResult<K> {
+        ThreadedRodeo::try_get_or_intern(self, val)
+    }
+
+    fn get_or_intern_static(&mut self, val: &'static str) -> K {
+        ThreadedRodeo::get_or_intern_static(self, val)
+    }
+
+    fn try_get_or_intern_static(&mut self, val: &'static str) -> crate::LassoResult<K> {
+        ThreadedRodeo::try_get_or_intern_static(self, val)
+    }
+}
+
+impl<K, S> Reader<K> for &ThreadedRodeo<K, S>
+where
+    K: Key + Hash,
+    S: BuildHasher + Clone,
+{
+    fn get(&self, val: &str) -> Option<K> {
+        ThreadedRodeo::get(self, val)
+    }
+
+    fn contains(&self, val: &str) -> bool {
+        ThreadedRodeo::contains(self, val)
+    }
+}
+
+impl<K, S> Resolver<K> for &ThreadedRodeo<K, S>
+where
+    K: Key + Hash,
+    S: BuildHasher + Clone,
+{
+    fn resolve<'a>(&'a self, key: &K) -> &'a str {
+        ThreadedRodeo::resolve(self, key)
+    }
+
+    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a str> {
+        ThreadedRodeo::try_resolve(self, key)
+    }
+
+    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a str {
+        ThreadedRodeo::resolve_unchecked(self, key)
+    }
+
+    fn contains_key(&self, key: &K) -> bool {
+        ThreadedRodeo::contains_key(self, key)
+    }
+
+    fn len(&self) -> usize {
+        ThreadedRodeo::len(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::tests::{filled_threaded_rodeo, INTERNED_STRINGS, UNINTERNED_STRINGS};
+    use super::*;
+    use crate::{Key, Spur};
+
+    #[test]
+    fn threaded_rodeo_ref_trait_implementations() {
+        let interner = filled_threaded_rodeo();
+        let shared_ref1 = &interner;
+        let shared_ref2 = &interner;
+        for (key, string) in INTERNED_STRINGS
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(i, s)| (Spur::try_from_usize(i).unwrap(), s))
+        {
+            assert!(shared_ref1.get(string).is_some());
+            assert!(shared_ref2.get(string).is_some());
+            assert!(shared_ref1.contains(string));
+            assert!(shared_ref2.contains(string));
+
+            assert!(shared_ref1.contains_key(&key));
+            assert!(shared_ref2.contains_key(&key));
+            assert_eq!(shared_ref1.resolve(&key), string);
+            assert_eq!(shared_ref2.resolve(&key), string);
+            assert!(shared_ref1.try_resolve(&key).is_some());
+            assert!(shared_ref2.try_resolve(&key).is_some());
+            assert_eq!(shared_ref1.try_resolve(&key), Some(string));
+            assert_eq!(shared_ref2.try_resolve(&key), Some(string));
+
+            unsafe {
+                assert_eq!(shared_ref1.resolve_unchecked(&key), string);
+                assert_eq!(shared_ref2.resolve_unchecked(&key), string);
+            }
+        }
+
+        assert_eq!(interner.len(), INTERNED_STRINGS.len());
+        for string in UNINTERNED_STRINGS.iter().copied() {
+            let key = interner.get_or_intern(string);
+            assert_eq!(shared_ref1.try_get_or_intern(string), Ok(key));
+            assert_eq!(shared_ref2.try_get_or_intern(string), Ok(key));
+            assert_eq!(shared_ref1.get_or_intern_static(string), key);
+            assert_eq!(shared_ref2.get_or_intern_static(string), key);
+            assert_eq!(shared_ref1.try_get_or_intern_static(string), Ok(key));
+            assert_eq!(shared_ref2.try_get_or_intern_static(string), Ok(key));
+
+            assert!(shared_ref1.get(string).is_some());
+            assert!(shared_ref2.get(string).is_some());
+            assert!(shared_ref1.contains(string));
+            assert!(shared_ref2.contains(string));
+
+            assert!(shared_ref1.contains_key(&key));
+            assert!(shared_ref2.contains_key(&key));
+            assert_eq!(shared_ref1.resolve(&key), string);
+            assert_eq!(shared_ref2.resolve(&key), string);
+            assert!(shared_ref1.try_resolve(&key).is_some());
+            assert!(shared_ref2.try_resolve(&key).is_some());
+            assert_eq!(shared_ref1.try_resolve(&key), Some(string));
+            assert_eq!(shared_ref2.try_resolve(&key), Some(string));
+
+            unsafe {
+                assert_eq!(shared_ref1.resolve_unchecked(&key), string);
+                assert_eq!(shared_ref2.resolve_unchecked(&key), string);
+            }
+        }
+        assert_eq!(
+            interner.len(),
+            INTERNED_STRINGS.len() + UNINTERNED_STRINGS.len(),
+        );
+    }
+}

--- a/src/interface/threaded_rodeo.rs
+++ b/src/interface/threaded_rodeo.rs
@@ -1,7 +1,7 @@
 //! Implementations of [`Interner`], [`Reader`] and [`Resolver`] for [`ThreadedRodeo`]
 #![cfg(feature = "multi-threaded")]
 
-use crate::{Interner, Key, LassoResult, Reader, Resolver, ThreadedRodeo};
+use crate::*;
 #[cfg(feature = "no-std")]
 use alloc::boxed::Box;
 use core::hash::{BuildHasher, Hash};
@@ -30,23 +30,38 @@ where
     fn try_get_or_intern_static(&mut self, val: &'static str) -> LassoResult<K> {
         (&*self).try_get_or_intern_static(val)
     }
+}
+
+impl<K, S> IntoReaderAndResolver<K> for ThreadedRodeo<K, S>
+where
+    K: Key + Hash,
+    S: BuildHasher + Clone,
+{
+}
+
+impl<K, S> IntoReader<K> for ThreadedRodeo<K, S>
+where
+    K: Key + Hash,
+    S: BuildHasher + Clone,
+{
+    type Reader = RodeoReader<K, S>;
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_reader(self) -> Box<dyn Reader<K>>
+    fn into_reader(self) -> Self::Reader
     where
         Self: 'static,
     {
-        Box::new(self.into_reader())
+        self.into_reader()
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_reader_boxed(self: Box<Self>) -> Box<dyn Reader<K>>
+    fn into_reader_boxed(self: Box<Self>) -> Self::Reader
     where
         Self: 'static,
     {
-        Box::new(ThreadedRodeo::into_reader(*self))
+        ThreadedRodeo::into_reader(*self)
     }
 }
 
@@ -64,23 +79,31 @@ where
     fn contains(&self, val: &str) -> bool {
         self.contains(val)
     }
+}
+
+impl<K, S> IntoResolver<K> for ThreadedRodeo<K, S>
+where
+    K: Key + Hash,
+    S: BuildHasher + Clone,
+{
+    type Resolver = RodeoResolver<K>;
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_resolver(self) -> Box<dyn Resolver<K>>
+    fn into_resolver(self) -> Self::Resolver
     where
         Self: 'static,
     {
-        Box::new(self.into_resolver())
+        self.into_resolver()
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    fn into_resolver_boxed(self: Box<Self>) -> Box<dyn Resolver<K>>
+    fn into_resolver_boxed(self: Box<Self>) -> Self::Resolver
     where
         Self: 'static,
     {
-        Box::new(ThreadedRodeo::into_resolver(*self))
+        ThreadedRodeo::into_resolver(*self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,7 +433,7 @@ mod reader;
 mod resolver;
 mod single_threaded;
 
-pub use interface::{Interner, Reader, Resolver};
+pub use interface::{Interner, IntoReader, IntoReaderAndResolver, IntoResolver, Reader, Resolver};
 pub use key::{Key, LargeSpur, MicroSpur, MiniSpur, Spur};
 pub use reader::RodeoReader;
 pub use resolver::RodeoResolver;


### PR DESCRIPTION
The latter allows taking a `&mut &ThreadedRodeo` as `&mut dyn Interner`, so users can benefit from the `multi-threading` feature when they use the traits.

Because you can't turn the shared reference `into_` a `Reader` or `Resolver` as you don't own it, I separated the corresponding methods into their own traits that sit on top of the base ones. The structure here is open to be discussed, there are a lot of possibilities between what traits to make requirements and maybe even what is needed here at all (e.g. just implementing `From` for the relevant combinations).
The way I went with for now adds associated types to the `Into` traits for the type of `Reader`/`Resolver` that they will create. Having this available as a generic removes the need to always return a `Box<dyn Trait>`. Again, there are options, from returning to boxed objects to making this a full-on generic on the trait. I personally don't see a reason for the latter, avoiding the generic could be interesting if one really wants to be generic over a lot of different types of interners.