### PR TITLE
Add blanket impls for `Resolver<K>`, `Reader<K>` and `Interner<K>`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   within it
 - Updated DashMap and Hashbrown dependencies
 
+### Added
+
+- Added blanket implementations of `Reader` and `Resolver` for `&T` and `&mut T` references to types that implement
+  those traits, and `Interner` likewise for `&mut T`
+
 ## [0.6.0] - 2021-09-01
 
 ### Changed

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -91,6 +91,36 @@ pub trait Reader<K = Spur>: Resolver<K> {
     fn contains(&self, val: &str) -> bool;
 }
 
+impl<T, K> Reader<K> for &T
+where
+    T: Reader<K>,
+{
+    #[inline]
+    fn get(&self, val: &str) -> Option<K> {
+        <T as Reader<K>>::get(self, val)
+    }
+
+    #[inline]
+    fn contains(&self, val: &str) -> bool {
+        <T as Reader<K>>::contains(self, val)
+    }
+}
+
+impl<T, K> Reader<K> for &mut T
+where
+    T: Reader<K>,
+{
+    #[inline]
+    fn get(&self, val: &str) -> Option<K> {
+        <T as Reader<K>>::get(self, val)
+    }
+
+    #[inline]
+    fn contains(&self, val: &str) -> bool {
+        <T as Reader<K>>::contains(self, val)
+    }
+}
+
 /// A generic interface over [`Reader`]s that can be turned into a [`Resolver`].
 pub trait IntoResolver<K = Spur>: Reader<K>
 where

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -150,3 +150,63 @@ pub trait Resolver<K = Spur> {
         self.len() == 0
     }
 }
+
+impl<T, K> Resolver<K> for &T
+where
+    T: Resolver<K>,
+{
+    #[inline]
+    fn resolve<'a>(&'a self, key: &K) -> &'a str {
+        <T as Resolver<K>>::resolve(self, key)
+    }
+
+    #[inline]
+    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a str> {
+        <T as Resolver<K>>::try_resolve(self, key)
+    }
+
+    #[inline]
+    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a str {
+        unsafe { <T as Resolver<K>>::resolve_unchecked(self, key) }
+    }
+
+    #[inline]
+    fn contains_key(&self, key: &K) -> bool {
+        <T as Resolver<K>>::contains_key(self, key)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        <T as Resolver<K>>::len(self)
+    }
+}
+
+impl<T, K> Resolver<K> for &mut T
+where
+    T: Resolver<K>,
+{
+    #[inline]
+    fn resolve<'a>(&'a self, key: &K) -> &'a str {
+        <T as Resolver<K>>::resolve(self, key)
+    }
+
+    #[inline]
+    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a str> {
+        <T as Resolver<K>>::try_resolve(self, key)
+    }
+
+    #[inline]
+    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a str {
+        unsafe { <T as Resolver<K>>::resolve_unchecked(self, key) }
+    }
+
+    #[inline]
+    fn contains_key(&self, key: &K) -> bool {
+        <T as Resolver<K>>::contains_key(self, key)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        <T as Resolver<K>>::len(self)
+    }
+}

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -48,6 +48,31 @@ pub trait Interner<K = Spur>: Reader<K> + Resolver<K> {
     fn try_get_or_intern_static(&mut self, val: &'static str) -> LassoResult<K>;
 }
 
+impl<T, K> Interner<K> for &mut T
+where
+    T: Interner<K>,
+{
+    #[inline]
+    fn get_or_intern(&mut self, val: &str) -> K {
+        <T as Interner<K>>::get_or_intern(self, val)
+    }
+
+    #[inline]
+    fn try_get_or_intern(&mut self, val: &str) -> LassoResult<K> {
+        <T as Interner<K>>::try_get_or_intern(self, val)
+    }
+
+    #[inline]
+    fn get_or_intern_static(&mut self, val: &'static str) -> K {
+        <T as Interner<K>>::get_or_intern_static(self, val)
+    }
+
+    #[inline]
+    fn try_get_or_intern_static(&mut self, val: &'static str) -> LassoResult<K> {
+        <T as Interner<K>>::try_get_or_intern_static(self, val)
+    }
+}
+
 /// A generic interface over interners that can be turned into both a [`Reader`] and a [`Resolver`]
 /// directly.
 pub trait IntoReaderAndResolver<K = Spur>: IntoReader<K> + IntoResolver<K>

--- a/src/interface/threaded_ref.rs
+++ b/src/interface/threaded_ref.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "multi-threaded")]
 
-use crate::{Interner, Key, Reader, ThreadedRodeo};
+use crate::{Interner, Key, ThreadedRodeo};
 use core::hash::{BuildHasher, Hash};
 
 impl<K, S> Interner<K> for &ThreadedRodeo<K, S>
@@ -22,20 +22,6 @@ where
 
     fn try_get_or_intern_static(&mut self, val: &'static str) -> crate::LassoResult<K> {
         ThreadedRodeo::try_get_or_intern_static(self, val)
-    }
-}
-
-impl<K, S> Reader<K> for &ThreadedRodeo<K, S>
-where
-    K: Key + Hash,
-    S: BuildHasher + Clone,
-{
-    fn get(&self, val: &str) -> Option<K> {
-        ThreadedRodeo::get(self, val)
-    }
-
-    fn contains(&self, val: &str) -> bool {
-        ThreadedRodeo::contains(self, val)
     }
 }
 

--- a/src/interface/threaded_ref.rs
+++ b/src/interface/threaded_ref.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "multi-threaded")]
 
-use crate::{Interner, Key, Reader, Resolver, ThreadedRodeo};
+use crate::{Interner, Key, Reader, ThreadedRodeo};
 use core::hash::{BuildHasher, Hash};
 
 impl<K, S> Interner<K> for &ThreadedRodeo<K, S>
@@ -39,37 +39,10 @@ where
     }
 }
 
-impl<K, S> Resolver<K> for &ThreadedRodeo<K, S>
-where
-    K: Key + Hash,
-    S: BuildHasher + Clone,
-{
-    fn resolve<'a>(&'a self, key: &K) -> &'a str {
-        ThreadedRodeo::resolve(self, key)
-    }
-
-    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a str> {
-        ThreadedRodeo::try_resolve(self, key)
-    }
-
-    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a str {
-        unsafe { ThreadedRodeo::resolve_unchecked(self, key) }
-    }
-
-    fn contains_key(&self, key: &K) -> bool {
-        ThreadedRodeo::contains_key(self, key)
-    }
-
-    fn len(&self) -> usize {
-        ThreadedRodeo::len(self)
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::super::tests::{filled_threaded_rodeo, INTERNED_STRINGS, UNINTERNED_STRINGS};
-    use super::*;
-    use crate::{Key, Spur};
+    use crate::{Key, Resolver, Spur};
 
     #[test]
     fn threaded_rodeo_ref_trait_implementations() {


### PR DESCRIPTION
I recently came across a situation where I was storing a `&mut Lasso` and needed to pass it in to something that expected a `T: Resolver`, and found that `&mut Lasso: !Resolver`. I would assume this isn't a particularly controversial addition, since these blanket impls are a pretty standard thing, but let me know if I've missed something important here.