### PR TITLE
Support non-str values in a Rodeo

### DIFF
--- a/src/arenas/atomic_bucket.rs
+++ b/src/arenas/atomic_bucket.rs
@@ -1,4 +1,4 @@
-use crate::{LassoError, LassoErrorKind, LassoResult};
+use crate::{Internable, LassoError, LassoErrorKind, LassoResult};
 use alloc::alloc::{alloc, dealloc, Layout};
 use core::{
     mem::{align_of, size_of},
@@ -189,7 +189,10 @@ impl UniqueBucketRef {
     /// Additionally, the underlying [`AtomicBucket`] must have enough room
     /// to store the entire slice and the given slice must be valid utf-8 data.
     ///
-    pub unsafe fn push_slice(&mut self, slice: &[u8]) -> &'static str {
+    pub unsafe fn push_slice<V>(&mut self, slice: &[u8]) -> &'static V
+    where
+        V: ?Sized + Internable,
+    {
         let len = self.len();
 
         if cfg!(debug_assertions) {
@@ -214,7 +217,7 @@ impl UniqueBucketRef {
         // Create a string from that slice
         // Safety: The source string was valid utf8, so the created buffer will be as well
 
-        unsafe { core::str::from_utf8_unchecked(target) }
+        unsafe { V::from_slice(target) }
     }
 }
 

--- a/src/arenas/bucket.rs
+++ b/src/arenas/bucket.rs
@@ -1,4 +1,4 @@
-use crate::{LassoError, LassoErrorKind, LassoResult};
+use crate::{Internable, LassoError, LassoErrorKind, LassoResult};
 use alloc::alloc::{alloc, dealloc, Layout};
 use core::{mem, num::NonZeroUsize, ptr::NonNull, slice};
 
@@ -61,7 +61,7 @@ impl Bucket {
     /// the caller promises to forget the reference before the arena is dropped.
     /// Additionally, `slice` must be valid UTF-8 and should come from an `&str`
     ///
-    pub(crate) unsafe fn push_slice(&mut self, slice: &[u8]) -> &'static str {
+    pub(crate) unsafe fn push_slice<V: ?Sized + Internable>(&mut self, slice: &[u8]) -> &'static V {
         debug_assert!(!self.is_full());
         debug_assert!(slice.len() <= self.capacity.get() - self.index);
 
@@ -78,7 +78,8 @@ impl Bucket {
 
             // Create a string from that slice
             // Safety: The source string was valid utf8, so the created buffer will be as well
-            core::str::from_utf8_unchecked(target)
+            V::from_slice(target)
+            // core::str::from_utf8_unchecked(target)
         }
     }
 }

--- a/src/interface/boxed.rs
+++ b/src/interface/boxed.rs
@@ -1,40 +1,42 @@
 use super::{Interner, IntoReader, IntoResolver, Reader, Resolver};
-use crate::{Key, LassoResult};
+use crate::{Internable, Key, LassoResult};
 #[cfg(feature = "no-std")]
 use alloc::boxed::Box;
 
-impl<K, I> Interner<K> for Box<I>
+impl<K, V, I> Interner<K, V> for Box<I>
 where
     K: Key,
-    I: Interner<K> + ?Sized + 'static,
+    V: ?Sized + Internable,
+    I: Interner<K, V> + ?Sized + 'static,
 {
     #[cfg_attr(feature = "inline-more", inline)]
-    fn get_or_intern(&mut self, val: &str) -> K {
+    fn get_or_intern(&mut self, val: &V) -> K {
         (&mut **self).get_or_intern(val)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn try_get_or_intern(&mut self, val: &str) -> LassoResult<K> {
+    fn try_get_or_intern(&mut self, val: &V) -> LassoResult<K> {
         (&mut **self).try_get_or_intern(val)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn get_or_intern_static(&mut self, val: &'static str) -> K {
+    fn get_or_intern_static(&mut self, val: &'static V) -> K {
         (&mut **self).get_or_intern_static(val)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn try_get_or_intern_static(&mut self, val: &'static str) -> LassoResult<K> {
+    fn try_get_or_intern_static(&mut self, val: &'static V) -> LassoResult<K> {
         self.try_get_or_intern(val)
     }
 }
 
-impl<K, I> IntoReader<K> for Box<I>
+impl<K, V, I> IntoReader<K, V> for Box<I>
 where
     K: Key,
-    I: IntoReader<K> + ?Sized + 'static,
+    V: ?Sized + Internable,
+    I: IntoReader<K, V> + ?Sized + 'static,
 {
-    type Reader = <I as IntoReader<K>>::Reader;
+    type Reader = <I as IntoReader<K, V>>::Reader;
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
@@ -55,28 +57,30 @@ where
     }
 }
 
-impl<K, I> Reader<K> for Box<I>
+impl<K, V, I> Reader<K, V> for Box<I>
 where
     K: Key,
-    I: Reader<K> + ?Sized + 'static,
+    V: ?Sized + Internable,
+    I: Reader<K, V> + ?Sized + 'static,
 {
     #[cfg_attr(feature = "inline-more", inline)]
-    fn get(&self, val: &str) -> Option<K> {
+    fn get(&self, val: &V) -> Option<K> {
         (&**self).get(val)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn contains(&self, val: &str) -> bool {
+    fn contains(&self, val: &V) -> bool {
         (&**self).contains(val)
     }
 }
 
-impl<K, I> IntoResolver<K> for Box<I>
+impl<K, V, I> IntoResolver<K, V> for Box<I>
 where
     K: Key,
-    I: IntoResolver<K> + ?Sized + 'static,
+    V: ?Sized + Internable,
+    I: IntoResolver<K, V> + ?Sized + 'static,
 {
-    type Resolver = <I as IntoResolver<K>>::Resolver;
+    type Resolver = <I as IntoResolver<K, V>>::Resolver;
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
@@ -97,23 +101,24 @@ where
     }
 }
 
-impl<K, I> Resolver<K> for Box<I>
+impl<K, V, I> Resolver<K, V> for Box<I>
 where
     K: Key,
-    I: Resolver<K> + ?Sized + 'static,
+    V: ?Sized + Internable,
+    I: Resolver<K, V> + ?Sized + 'static,
 {
     #[cfg_attr(feature = "inline-more", inline)]
-    fn resolve<'a>(&'a self, key: &K) -> &'a str {
+    fn resolve<'a>(&'a self, key: &K) -> &'a V {
         (&**self).resolve(key)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a str> {
+    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a V> {
         (&**self).try_resolve(key)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a str {
+    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a V {
         unsafe { (&**self).resolve_unchecked(key) }
     }
 

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -6,7 +6,7 @@ mod tests;
 mod threaded_ref;
 mod threaded_rodeo;
 
-use crate::{Key, LassoResult, Spur};
+use crate::{Internable, Key, LassoResult, Spur};
 #[cfg(feature = "no-std")]
 use alloc::boxed::Box;
 
@@ -16,7 +16,7 @@ use alloc::boxed::Box;
 /// Note that because single-threaded [`Rodeo`](crate::Rodeo)s require mutable access to use, this
 /// trait does so as well. For use with [`ThreadedRodeo`](crate::ThreadedRodeo), the trait is
 /// implemented for `&ThreadedRodeo` as well to allow access through shared references.
-pub trait Interner<K = Spur>: Reader<K> + Resolver<K> {
+pub trait Interner<K = Spur, V: ?Sized = str>: Reader<K, V> + Resolver<K, V> {
     /// Get the key for a string, interning it if it does not yet exist
     ///
     /// # Panics
@@ -25,10 +25,10 @@ pub trait Interner<K = Spur>: Reader<K> + Resolver<K> {
     /// keys, this means that you've interned more strings than it can handle. (For [`Spur`] this
     /// means that `u32::MAX - 1` unique strings were interned)
     ///
-    fn get_or_intern(&mut self, val: &str) -> K;
+    fn get_or_intern(&mut self, val: &V) -> K;
 
     /// Get the key for a string, interning it if it does not yet exist
-    fn try_get_or_intern(&mut self, val: &str) -> LassoResult<K>;
+    fn try_get_or_intern(&mut self, val: &V) -> LassoResult<K>;
 
     /// Get the key for a static string, interning it if it does not yet exist
     ///
@@ -40,54 +40,57 @@ pub trait Interner<K = Spur>: Reader<K> + Resolver<K> {
     /// keys, this means that you've interned more strings than it can handle. (For [`Spur`] this
     /// means that `u32::MAX - 1` unique strings were interned)
     ///
-    fn get_or_intern_static(&mut self, val: &'static str) -> K;
+    fn get_or_intern_static(&mut self, val: &'static V) -> K;
 
     /// Get the key for a static string, interning it if it does not yet exist
     ///
     /// This will not reallocate or copy the given string
-    fn try_get_or_intern_static(&mut self, val: &'static str) -> LassoResult<K>;
+    fn try_get_or_intern_static(&mut self, val: &'static V) -> LassoResult<K>;
 }
 
-impl<T, K> Interner<K> for &mut T
+impl<T, K, V> Interner<K, V> for &mut T
 where
-    T: Interner<K>,
+    V: ?Sized,
+    T: Interner<K, V>,
 {
     #[inline]
-    fn get_or_intern(&mut self, val: &str) -> K {
-        <T as Interner<K>>::get_or_intern(self, val)
+    fn get_or_intern(&mut self, val: &V) -> K {
+        <T as Interner<K, V>>::get_or_intern(self, val)
     }
 
     #[inline]
-    fn try_get_or_intern(&mut self, val: &str) -> LassoResult<K> {
-        <T as Interner<K>>::try_get_or_intern(self, val)
+    fn try_get_or_intern(&mut self, val: &V) -> LassoResult<K> {
+        <T as Interner<K, V>>::try_get_or_intern(self, val)
     }
 
     #[inline]
-    fn get_or_intern_static(&mut self, val: &'static str) -> K {
-        <T as Interner<K>>::get_or_intern_static(self, val)
+    fn get_or_intern_static(&mut self, val: &'static V) -> K {
+        <T as Interner<K, V>>::get_or_intern_static(self, val)
     }
 
     #[inline]
-    fn try_get_or_intern_static(&mut self, val: &'static str) -> LassoResult<K> {
-        <T as Interner<K>>::try_get_or_intern_static(self, val)
+    fn try_get_or_intern_static(&mut self, val: &'static V) -> LassoResult<K> {
+        <T as Interner<K, V>>::try_get_or_intern_static(self, val)
     }
 }
 
 /// A generic interface over interners that can be turned into both a [`Reader`] and a [`Resolver`]
 /// directly.
-pub trait IntoReaderAndResolver<K = Spur>: IntoReader<K> + IntoResolver<K>
+pub trait IntoReaderAndResolver<K = Spur, V = str>: IntoReader<K, V> + IntoResolver<K, V>
 where
     K: Key,
+    V: ?Sized + Internable,
 {
 }
 
 /// A generic interface over interners that can be turned into a [`Reader`].
-pub trait IntoReader<K = Spur>: Interner<K>
+pub trait IntoReader<K = Spur, V = str>: Interner<K, V>
 where
     K: Key,
+    V: ?Sized + Internable,
 {
     /// The type of [`Reader`] the interner will be converted into
-    type Reader: Reader<K>;
+    type Reader: Reader<K, V>;
 
     /// Consumes the current [`Interner`] and converts it into a [`Reader`] to allow
     /// contention-free access of the interner from multiple threads
@@ -108,51 +111,54 @@ where
 /// A generic interface that allows using any underlying interner for
 /// both its reading and resolution capabilities, allowing both
 /// `str -> key` and `key -> str` lookups
-pub trait Reader<K = Spur>: Resolver<K> {
+pub trait Reader<K = Spur, V: ?Sized = str>: Resolver<K, V> {
     /// Get a key for the given string value if it exists
-    fn get(&self, val: &str) -> Option<K>;
+    fn get(&self, val: &V) -> Option<K>;
 
     /// Returns `true` if the current interner contains the given string
-    fn contains(&self, val: &str) -> bool;
+    fn contains(&self, val: &V) -> bool;
 }
 
-impl<T, K> Reader<K> for &T
+impl<T, V, K> Reader<K, V> for &T
 where
-    T: Reader<K>,
+    V: ?Sized,
+    T: Reader<K, V>,
 {
     #[inline]
-    fn get(&self, val: &str) -> Option<K> {
-        <T as Reader<K>>::get(self, val)
+    fn get(&self, val: &V) -> Option<K> {
+        <T as Reader<K, V>>::get(self, val)
     }
 
     #[inline]
-    fn contains(&self, val: &str) -> bool {
-        <T as Reader<K>>::contains(self, val)
+    fn contains(&self, val: &V) -> bool {
+        <T as Reader<K, V>>::contains(self, val)
     }
 }
 
-impl<T, K> Reader<K> for &mut T
+impl<T, V, K> Reader<K, V> for &mut T
 where
-    T: Reader<K>,
+    V: ?Sized,
+    T: Reader<K, V>,
 {
     #[inline]
-    fn get(&self, val: &str) -> Option<K> {
-        <T as Reader<K>>::get(self, val)
+    fn get(&self, val: &V) -> Option<K> {
+        <T as Reader<K, V>>::get(self, val)
     }
 
     #[inline]
-    fn contains(&self, val: &str) -> bool {
-        <T as Reader<K>>::contains(self, val)
+    fn contains(&self, val: &V) -> bool {
+        <T as Reader<K, V>>::contains(self, val)
     }
 }
 
 /// A generic interface over [`Reader`]s that can be turned into a [`Resolver`].
-pub trait IntoResolver<K = Spur>: Reader<K>
+pub trait IntoResolver<K = Spur, V = str>: Reader<K, V>
 where
     K: Key,
+    V: ?Sized + Internable,
 {
     /// The type of [`Resolver`] the reader will be converted into
-    type Resolver: Resolver<K>;
+    type Resolver: Resolver<K, V>;
 
     /// Consumes the current [`Reader`] and makes it into a [`Resolver`], allowing
     /// contention-free access from multiple threads with the lowest possible memory consumption
@@ -172,18 +178,18 @@ where
 
 /// A generic interface that allows using any underlying interner only
 /// for its resolution capabilities, allowing only `key -> str` lookups
-pub trait Resolver<K = Spur> {
+pub trait Resolver<K = Spur, V: ?Sized = str> {
     /// Resolves the given key into a string
     ///
     /// # Panics
     ///
     /// Panics if the key is not contained in the current [`Resolver`]
     ///
-    fn resolve<'a>(&'a self, key: &K) -> &'a str;
+    fn resolve<'a>(&'a self, key: &K) -> &'a V;
 
     /// Attempts to resolve the given key into a string, returning `None`
     /// if it cannot be found
-    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a str>;
+    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a V>;
 
     /// Resolves a string by its key without preforming bounds checks
     ///
@@ -191,7 +197,7 @@ pub trait Resolver<K = Spur> {
     ///
     /// The key must be valid for the current [`Resolver`]
     ///
-    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a str;
+    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a V;
 
     /// Returns `true` if the current interner contains the given key
     fn contains_key(&self, key: &K) -> bool;
@@ -206,62 +212,64 @@ pub trait Resolver<K = Spur> {
     }
 }
 
-impl<T, K> Resolver<K> for &T
+impl<T, V, K> Resolver<K, V> for &T
 where
-    T: Resolver<K>,
+    V: ?Sized,
+    T: Resolver<K, V>,
 {
     #[inline]
-    fn resolve<'a>(&'a self, key: &K) -> &'a str {
-        <T as Resolver<K>>::resolve(self, key)
+    fn resolve<'a>(&'a self, key: &K) -> &'a V {
+        <T as Resolver<K, V>>::resolve(self, key)
     }
 
     #[inline]
-    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a str> {
-        <T as Resolver<K>>::try_resolve(self, key)
+    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a V> {
+        <T as Resolver<K, V>>::try_resolve(self, key)
     }
 
     #[inline]
-    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a str {
-        unsafe { <T as Resolver<K>>::resolve_unchecked(self, key) }
+    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a V {
+        unsafe { <T as Resolver<K, V>>::resolve_unchecked(self, key) }
     }
 
     #[inline]
     fn contains_key(&self, key: &K) -> bool {
-        <T as Resolver<K>>::contains_key(self, key)
+        <T as Resolver<K, V>>::contains_key(self, key)
     }
 
     #[inline]
     fn len(&self) -> usize {
-        <T as Resolver<K>>::len(self)
+        <T as Resolver<K, V>>::len(self)
     }
 }
 
-impl<T, K> Resolver<K> for &mut T
+impl<T, V, K> Resolver<K, V> for &mut T
 where
-    T: Resolver<K>,
+    V: ?Sized,
+    T: Resolver<K, V>,
 {
     #[inline]
-    fn resolve<'a>(&'a self, key: &K) -> &'a str {
-        <T as Resolver<K>>::resolve(self, key)
+    fn resolve<'a>(&'a self, key: &K) -> &'a V {
+        <T as Resolver<K, V>>::resolve(self, key)
     }
 
     #[inline]
-    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a str> {
-        <T as Resolver<K>>::try_resolve(self, key)
+    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a V> {
+        <T as Resolver<K, V>>::try_resolve(self, key)
     }
 
     #[inline]
-    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a str {
-        unsafe { <T as Resolver<K>>::resolve_unchecked(self, key) }
+    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a V {
+        unsafe { <T as Resolver<K, V>>::resolve_unchecked(self, key) }
     }
 
     #[inline]
     fn contains_key(&self, key: &K) -> bool {
-        <T as Resolver<K>>::contains_key(self, key)
+        <T as Resolver<K, V>>::contains_key(self, key)
     }
 
     #[inline]
     fn len(&self) -> usize {
-        <T as Resolver<K>>::len(self)
+        <T as Resolver<K, V>>::len(self)
     }
 }

--- a/src/interface/rodeo.rs
+++ b/src/interface/rodeo.rs
@@ -6,45 +6,48 @@ use alloc::boxed::Box;
 use core::hash::BuildHasher;
 use interface::IntoReaderAndResolver;
 
-impl<K, S> Interner<K> for Rodeo<K, S>
+impl<K, V, S> Interner<K, V> for Rodeo<K, V, S>
 where
     K: Key,
+    V: ?Sized + Internable,
     S: BuildHasher,
 {
     #[cfg_attr(feature = "inline-more", inline)]
-    fn get_or_intern(&mut self, val: &str) -> K {
+    fn get_or_intern(&mut self, val: &V) -> K {
         self.get_or_intern(val)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn try_get_or_intern(&mut self, val: &str) -> LassoResult<K> {
+    fn try_get_or_intern(&mut self, val: &V) -> LassoResult<K> {
         self.try_get_or_intern(val)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn get_or_intern_static(&mut self, val: &'static str) -> K {
+    fn get_or_intern_static(&mut self, val: &'static V) -> K {
         self.get_or_intern_static(val)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn try_get_or_intern_static(&mut self, val: &'static str) -> LassoResult<K> {
+    fn try_get_or_intern_static(&mut self, val: &'static V) -> LassoResult<K> {
         self.try_get_or_intern_static(val)
     }
 }
 
-impl<K, S> IntoReaderAndResolver<K> for Rodeo<K, S>
+impl<K, V, S> IntoReaderAndResolver<K, V> for Rodeo<K, V, S>
 where
     K: Key,
+    V: ?Sized + Internable,
     S: BuildHasher,
 {
 }
 
-impl<K, S> IntoReader<K> for Rodeo<K, S>
+impl<K, V, S> IntoReader<K, V> for Rodeo<K, V, S>
 where
     K: Key,
+    V: ?Sized + Internable,
     S: BuildHasher,
 {
-    type Reader = RodeoReader<K, S>;
+    type Reader = RodeoReader<K, V, S>;
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
@@ -65,28 +68,30 @@ where
     }
 }
 
-impl<K, S> Reader<K> for Rodeo<K, S>
+impl<K, V, S> Reader<K, V> for Rodeo<K, V, S>
 where
     K: Key,
+    V: ?Sized + Internable,
     S: BuildHasher,
 {
     #[cfg_attr(feature = "inline-more", inline)]
-    fn get(&self, val: &str) -> Option<K> {
+    fn get(&self, val: &V) -> Option<K> {
         self.get(val)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn contains(&self, val: &str) -> bool {
+    fn contains(&self, val: &V) -> bool {
         self.contains(val)
     }
 }
 
-impl<K, S> IntoResolver<K> for Rodeo<K, S>
+impl<K, V, S> IntoResolver<K, V> for Rodeo<K, V, S>
 where
     K: Key,
+    V: ?Sized + Internable,
     S: BuildHasher,
 {
-    type Resolver = RodeoResolver<K>;
+    type Resolver = RodeoResolver<K, V>;
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
@@ -107,22 +112,23 @@ where
     }
 }
 
-impl<K, S> Resolver<K> for Rodeo<K, S>
+impl<K, V, S> Resolver<K, V> for Rodeo<K, V, S>
 where
     K: Key,
+    V: ?Sized + Internable,
 {
     #[cfg_attr(feature = "inline-more", inline)]
-    fn resolve<'a>(&'a self, key: &K) -> &'a str {
+    fn resolve<'a>(&'a self, key: &K) -> &'a V {
         self.resolve(key)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a str> {
+    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a V> {
         self.try_resolve(key)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a str {
+    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a V {
         unsafe { self.resolve_unchecked(key) }
     }
 

--- a/src/interface/rodeo_reader.rs
+++ b/src/interface/rodeo_reader.rs
@@ -1,32 +1,34 @@
 //! Implementations of [`Reader`] and [`Resolver`] for [`RodeoReader`]
 
-use crate::{IntoResolver, Key, Reader, Resolver, RodeoReader, RodeoResolver};
+use crate::{Internable, IntoResolver, Key, Reader, Resolver, RodeoReader, RodeoResolver};
 #[cfg(feature = "no-std")]
 use alloc::boxed::Box;
 use core::hash::BuildHasher;
 
-impl<K, S> Reader<K> for RodeoReader<K, S>
+impl<K, V, S> Reader<K, V> for RodeoReader<K, V, S>
 where
     K: Key,
+    V: ?Sized + Internable,
     S: BuildHasher,
 {
     #[cfg_attr(feature = "inline-more", inline)]
-    fn get(&self, val: &str) -> Option<K> {
+    fn get(&self, val: &V) -> Option<K> {
         self.get(val)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn contains(&self, val: &str) -> bool {
+    fn contains(&self, val: &V) -> bool {
         self.contains(val)
     }
 }
 
-impl<K, S> IntoResolver<K> for RodeoReader<K, S>
+impl<K, V, S> IntoResolver<K, V> for RodeoReader<K, V, S>
 where
     K: Key,
+    V: ?Sized + Internable,
     S: BuildHasher,
 {
-    type Resolver = RodeoResolver<K>;
+    type Resolver = RodeoResolver<K, V>;
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
@@ -47,22 +49,23 @@ where
     }
 }
 
-impl<K, S> Resolver<K> for RodeoReader<K, S>
+impl<K, V, S> Resolver<K, V> for RodeoReader<K, V, S>
 where
     K: Key,
+    V: ?Sized + Internable,
 {
     #[cfg_attr(feature = "inline-more", inline)]
-    fn resolve<'a>(&'a self, key: &K) -> &'a str {
+    fn resolve<'a>(&'a self, key: &K) -> &'a V {
         self.resolve(key)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a str> {
+    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a V> {
         self.try_resolve(key)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a str {
+    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a V {
         unsafe { self.resolve_unchecked(key) }
     }
 

--- a/src/interface/rodeo_resolver.rs
+++ b/src/interface/rodeo_resolver.rs
@@ -1,23 +1,24 @@
 //! Implementations of [`Resolver`] for [`RodeoResolver`]
 
-use crate::{Key, Resolver, RodeoResolver};
+use crate::{Internable, Key, Resolver, RodeoResolver};
 
-impl<K> Resolver<K> for RodeoResolver<K>
+impl<K, V> Resolver<K, V> for RodeoResolver<K, V>
 where
     K: Key,
+    V: ?Sized + Internable,
 {
     #[cfg_attr(feature = "inline-more", inline)]
-    fn resolve<'a>(&'a self, key: &K) -> &'a str {
+    fn resolve<'a>(&'a self, key: &K) -> &'a V {
         self.resolve(key)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a str> {
+    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a V> {
         self.try_resolve(key)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a str {
+    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a V {
         unsafe { self.resolve_unchecked(key) }
     }
 

--- a/src/interface/threaded_ref.rs
+++ b/src/interface/threaded_ref.rs
@@ -1,26 +1,27 @@
 #![cfg(feature = "multi-threaded")]
 
-use crate::{Interner, Key, ThreadedRodeo};
+use crate::{Internable, Interner, Key, ThreadedRodeo};
 use core::hash::{BuildHasher, Hash};
 
-impl<K, S> Interner<K> for &ThreadedRodeo<K, S>
+impl<K, V, S> Interner<K, V> for &ThreadedRodeo<K, V, S>
 where
     K: Key + Hash,
+    V: ?Sized + Internable,
     S: BuildHasher + Clone,
 {
-    fn get_or_intern(&mut self, val: &str) -> K {
+    fn get_or_intern(&mut self, val: &V) -> K {
         ThreadedRodeo::get_or_intern(self, val)
     }
 
-    fn try_get_or_intern(&mut self, val: &str) -> crate::LassoResult<K> {
+    fn try_get_or_intern(&mut self, val: &V) -> crate::LassoResult<K> {
         ThreadedRodeo::try_get_or_intern(self, val)
     }
 
-    fn get_or_intern_static(&mut self, val: &'static str) -> K {
+    fn get_or_intern_static(&mut self, val: &'static V) -> K {
         ThreadedRodeo::get_or_intern_static(self, val)
     }
 
-    fn try_get_or_intern_static(&mut self, val: &'static str) -> crate::LassoResult<K> {
+    fn try_get_or_intern_static(&mut self, val: &'static V) -> crate::LassoResult<K> {
         ThreadedRodeo::try_get_or_intern_static(self, val)
     }
 }

--- a/src/interface/threaded_rodeo.rs
+++ b/src/interface/threaded_rodeo.rs
@@ -6,45 +6,48 @@ use crate::*;
 use alloc::boxed::Box;
 use core::hash::{BuildHasher, Hash};
 
-impl<K, S> Interner<K> for ThreadedRodeo<K, S>
+impl<K, V, S> Interner<K, V> for ThreadedRodeo<K, V, S>
 where
     K: Key + Hash,
+    V: ?Sized + Internable,
     S: BuildHasher + Clone,
 {
     #[cfg_attr(feature = "inline-more", inline)]
-    fn get_or_intern(&mut self, val: &str) -> K {
+    fn get_or_intern(&mut self, val: &V) -> K {
         (&*self).get_or_intern(val)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn try_get_or_intern(&mut self, val: &str) -> LassoResult<K> {
+    fn try_get_or_intern(&mut self, val: &V) -> LassoResult<K> {
         (&*self).try_get_or_intern(val)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn get_or_intern_static(&mut self, val: &'static str) -> K {
+    fn get_or_intern_static(&mut self, val: &'static V) -> K {
         (&*self).get_or_intern_static(val)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn try_get_or_intern_static(&mut self, val: &'static str) -> LassoResult<K> {
+    fn try_get_or_intern_static(&mut self, val: &'static V) -> LassoResult<K> {
         (&*self).try_get_or_intern_static(val)
     }
 }
 
-impl<K, S> IntoReaderAndResolver<K> for ThreadedRodeo<K, S>
+impl<K, V, S> IntoReaderAndResolver<K, V> for ThreadedRodeo<K, V, S>
 where
     K: Key + Hash,
+    V: ?Sized + Internable,
     S: BuildHasher + Clone,
 {
 }
 
-impl<K, S> IntoReader<K> for ThreadedRodeo<K, S>
+impl<K, V, S> IntoReader<K, V> for ThreadedRodeo<K, V, S>
 where
     K: Key + Hash,
+    V: ?Sized + Internable,
     S: BuildHasher + Clone,
 {
-    type Reader = RodeoReader<K, S>;
+    type Reader = RodeoReader<K, V, S>;
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
@@ -65,28 +68,30 @@ where
     }
 }
 
-impl<K, S> Reader<K> for ThreadedRodeo<K, S>
+impl<K, V, S> Reader<K, V> for ThreadedRodeo<K, V, S>
 where
     K: Key + Hash,
+    V: ?Sized + Internable,
     S: BuildHasher + Clone,
 {
     #[cfg_attr(feature = "inline-more", inline)]
-    fn get(&self, val: &str) -> Option<K> {
+    fn get(&self, val: &V) -> Option<K> {
         self.get(val)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn contains(&self, val: &str) -> bool {
+    fn contains(&self, val: &V) -> bool {
         self.contains(val)
     }
 }
 
-impl<K, S> IntoResolver<K> for ThreadedRodeo<K, S>
+impl<K, V, S> IntoResolver<K, V> for ThreadedRodeo<K, V, S>
 where
     K: Key + Hash,
+    V: ?Sized + Internable,
     S: BuildHasher + Clone,
 {
-    type Resolver = RodeoResolver<K>;
+    type Resolver = RodeoResolver<K, V>;
 
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
@@ -107,25 +112,26 @@ where
     }
 }
 
-impl<K, S> Resolver<K> for ThreadedRodeo<K, S>
+impl<K, V, S> Resolver<K, V> for ThreadedRodeo<K, V, S>
 where
     K: Key + Hash,
+    V: ?Sized + Internable,
     S: BuildHasher + Clone,
 {
     #[cfg_attr(feature = "inline-more", inline)]
-    fn resolve<'a>(&'a self, key: &K) -> &'a str {
+    fn resolve<'a>(&'a self, key: &K) -> &'a V {
         self.resolve(key)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a str> {
+    fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a V> {
         self.try_resolve(key)
     }
 
     /// [`ThreadedRodeo`] does not actually have a `resolve_unchecked()` method,
     /// so this just forwards to the normal [`ThreadedRodeo::resolve()`] method
     #[cfg_attr(feature = "inline-more", inline)]
-    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a str {
+    unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a V {
         self.resolve(key)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,7 +446,7 @@ pub use keys::{Key, LargeSpur, MicroSpur, MiniSpur, Spur};
 pub use reader::RodeoReader;
 pub use resolver::RodeoResolver;
 pub use rodeo::Rodeo;
-pub use util::{Capacity, Iter, LassoError, LassoErrorKind, LassoResult, MemoryLimits, Strings};
+pub use util::{Capacity, Iter, LassoError, LassoErrorKind, LassoResult, MemoryLimits, Strings, Internable};
 
 compile! {
     if #[all(feature = "multi-threaded", not(feature = "no-std"))] {

--- a/src/rodeo.rs
+++ b/src/rodeo.rs
@@ -1,18 +1,11 @@
-use crate::{
-    arenas::{AnyArena, Arena},
-    hasher::RandomState,
-    keys::{Key, Spur},
-    reader::RodeoReader,
-    resolver::RodeoResolver,
-    util::{Iter, Strings},
-    Capacity, LassoError, LassoErrorKind, LassoResult, MemoryLimits,
-};
+use crate::{arenas::{AnyArena, Arena}, hasher::RandomState, keys::{Key, Spur}, reader::RodeoReader, resolver::RodeoResolver, util::{Iter, Strings}, Capacity, LassoError, LassoErrorKind, LassoResult, MemoryLimits, Internable};
 use alloc::vec::Vec;
 use core::{
-    hash::{BuildHasher, Hash, Hasher},
+    hash::{BuildHasher, Hasher},
     iter::FromIterator,
     ops::Index,
 };
+use core::marker::PhantomData;
 use hashbrown::{hash_map::RawEntryMut, HashMap};
 
 /// A string interner that caches strings quickly with a minimal memory footprint,
@@ -23,7 +16,7 @@ use hashbrown::{hash_map::RawEntryMut, HashMap};
 /// [`Spur`]: crate::Spur
 /// [`RandomState`]: https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html
 #[derive(Debug)]
-pub struct Rodeo<K = Spur, S = RandomState> {
+pub struct Rodeo<K = Spur, V: ?Sized + 'static = str, S = RandomState> {
     /// Map that allows `str` -> `key` resolution
     ///
     /// This must be a `HashMap` (for now) since `raw_api`s are only available for maps and not sets.
@@ -43,14 +36,16 @@ pub struct Rodeo<K = Spur, S = RandomState> {
     /// custom hashing on the keys of the map without the map itself trying to do something else
     hasher: S,
     /// Vec that allows `key` -> `str` resolution
-    pub(crate) strings: Vec<&'static str>,
+    pub(crate) strings: Vec<&'static V>,
     /// The arena that holds all allocated strings
     arena: Arena,
+    phantom: PhantomData<V>,
 }
 
-impl<K> Rodeo<K, RandomState>
+impl<K, V> Rodeo<K, V, RandomState>
 where
     K: Key,
+    V: ?Sized + Internable,
 {
     /// Create a new Rodeo
     ///
@@ -154,9 +149,10 @@ where
     }
 }
 
-impl<K, S> Rodeo<K, S>
+impl<K, V, S> Rodeo<K, V, S>
 where
     K: Key,
+    V: ?Sized + Internable,
     S: BuildHasher,
 {
     /// Creates an empty Rodeo which will use the given hasher for its internal hashmap
@@ -167,7 +163,7 @@ where
     /// use lasso::{Spur, Rodeo};
     /// use std::collections::hash_map::RandomState;
     ///
-    /// let rodeo: Rodeo<Spur, RandomState> = Rodeo::with_hasher(RandomState::new());
+    /// let rodeo: Rodeo<Spur, str, RandomState> = Rodeo::with_hasher(RandomState::new());
     /// ```
     ///
     #[cfg_attr(feature = "inline-more", inline)]
@@ -189,7 +185,7 @@ where
     /// use lasso::{Spur, Capacity, Rodeo};
     /// use std::collections::hash_map::RandomState;
     ///
-    /// let rodeo: Rodeo<Spur, RandomState> = Rodeo::with_capacity_and_hasher(Capacity::for_strings(10), RandomState::new());
+    /// let rodeo: Rodeo<Spur, str, RandomState> = Rodeo::with_capacity_and_hasher(Capacity::for_strings(10), RandomState::new());
     /// ```
     ///
     /// [`Capacity`]: crate::Capacity
@@ -212,7 +208,7 @@ where
     /// use lasso::{Spur, Capacity, MemoryLimits, Rodeo};
     /// use std::collections::hash_map::RandomState;
     ///
-    /// let rodeo: Rodeo<Spur, RandomState> = Rodeo::with_capacity_memory_limits_and_hasher(
+    /// let rodeo: Rodeo<Spur, str, RandomState> = Rodeo::with_capacity_memory_limits_and_hasher(
     ///     Capacity::for_strings(10),
     ///     MemoryLimits::for_memory_usage(4096),
     ///     RandomState::new(),
@@ -236,6 +232,7 @@ where
             strings: Vec::with_capacity(strings),
             arena: Arena::new(bytes, max_memory_usage)
                 .expect("failed to allocate memory for interner"),
+            phantom: PhantomData,
         }
     }
 
@@ -267,7 +264,7 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn get_or_intern<T>(&mut self, val: T) -> K
     where
-        T: AsRef<str>,
+        T: AsRef<V>,
     {
         self.try_get_or_intern(val)
             .expect("Failed to get or intern string")
@@ -294,16 +291,17 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn try_get_or_intern<T>(&mut self, val: T) -> LassoResult<K>
     where
-        T: AsRef<str>,
+        T: AsRef<V>,
     {
         let Self {
             map,
             hasher,
             strings,
             arena,
+            phantom: _,
         } = self;
 
-        let string_slice: &str = val.as_ref();
+        let string_slice: &V = val.as_ref();
 
         // Make a hash of the requested string
         let hash = {
@@ -316,7 +314,7 @@ where
         // Get the map's entry that the string should occupy
         let entry = map.raw_entry_mut().from_hash(hash, |key| {
             // Safety: The index given by `key` will be in bounds of the strings vector
-            let key_string: &str = unsafe { index_unchecked!(strings, key.into_usize()) };
+            let key_string: &V = unsafe { index_unchecked!(strings, key.into_usize()) };
 
             // Compare the requested string against the key's string
             string_slice == key_string
@@ -341,7 +339,7 @@ where
 
                 // Insert the key with the hash of the string that it points to, reusing the hash we made earlier
                 entry.insert_with_hasher(hash, key, (), |key| {
-                    let key_string: &str = unsafe { index_unchecked!(strings, key.into_usize()) };
+                    let key_string: &V = unsafe { index_unchecked!(strings, key.into_usize()) };
 
                     let mut state = hasher.build_hasher();
                     key_string.hash(&mut state);
@@ -383,7 +381,7 @@ where
     /// ```
     ///
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn get_or_intern_static(&mut self, string: &'static str) -> K {
+    pub fn get_or_intern_static(&mut self, string: &'static V) -> K {
         self.try_get_or_intern_static(string)
             .expect("Failed to get or intern static string")
     }
@@ -409,7 +407,7 @@ where
     /// ```
     ///
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn try_get_or_intern_static(&mut self, string: &'static str) -> LassoResult<K> {
+    pub fn try_get_or_intern_static(&mut self, string: &'static V) -> LassoResult<K> {
         let Self {
             map,
             hasher,
@@ -428,7 +426,7 @@ where
         // Get the map's entry that the string should occupy
         let entry = map.raw_entry_mut().from_hash(hash, |key| {
             // Safety: The index given by `key` will be in bounds of the strings vector
-            let key_string: &str = unsafe { index_unchecked!(strings, key.into_usize()) };
+            let key_string: &V = unsafe { index_unchecked!(strings, key.into_usize()) };
 
             // Compare the requested string against the key's string
             string == key_string
@@ -449,7 +447,7 @@ where
 
                 // Insert the key with the hash of the string that it points to, reusing the hash we made earlier
                 entry.insert_with_hasher(hash, key, (), |key| {
-                    let key_string: &str = unsafe { index_unchecked!(strings, key.into_usize()) };
+                    let key_string: &V = unsafe { index_unchecked!(strings, key.into_usize()) };
 
                     let mut state = hasher.build_hasher();
                     key_string.hash(&mut state);
@@ -482,9 +480,9 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn get<T>(&self, val: T) -> Option<K>
     where
-        T: AsRef<str>,
+        T: AsRef<V>,
     {
-        let string_slice: &str = val.as_ref();
+        let string_slice: &V = val.as_ref();
 
         // Make a hash of the requested string
         let hash = {
@@ -497,7 +495,7 @@ where
         // Get the map's entry that the string should occupy
         let entry = self.map.raw_entry().from_hash(hash, |key| {
             // Safety: The index given by `key` will be in bounds of the strings vector
-            let key_string: &str = unsafe { index_unchecked!(self.strings, key.into_usize()) };
+            let key_string: &V = unsafe { index_unchecked!(self.strings, key.into_usize()) };
 
             // Compare the requested string against the
             string_slice == key_string
@@ -524,15 +522,16 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn contains<T>(&self, val: T) -> bool
     where
-        T: AsRef<str>,
+        T: AsRef<V>,
     {
         self.get(val).is_some()
     }
 }
 
-impl<K, S> Rodeo<K, S>
+impl<K, V, S> Rodeo<K, V, S>
 where
     K: Key,
+    V: ?Sized + Internable,
 {
     /// Returns `true` if the given key exists in the current interner
     ///
@@ -574,7 +573,7 @@ where
     /// ```
     ///
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn resolve<'a>(&'a self, key: &K) -> &'a str {
+    pub fn resolve<'a>(&'a self, key: &K) -> &'a V {
         // Safety: The call to get_unchecked's safety relies on the Key::into_usize impl
         // being symmetric and the caller having not fabricated a key. If the impl is sound
         // and symmetric, then it will succeed, as the usize used to create it is a valid
@@ -600,7 +599,7 @@ where
     /// ```
     ///
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a str> {
+    pub fn try_resolve<'a>(&'a self, key: &K) -> Option<&'a V> {
         // Safety: The call to get_unchecked's safety relies on the Key::into_usize impl
         // being symmetric and the caller having not fabricated a key. If the impl is sound
         // and symmetric, then it will succeed, as the usize used to create it is a valid
@@ -634,12 +633,12 @@ where
     /// ```
     ///
     #[cfg_attr(feature = "inline-more", inline)]
-    pub unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a str {
+    pub unsafe fn resolve_unchecked<'a>(&'a self, key: &K) -> &'a V {
         unsafe { self.strings.get_unchecked(key.into_usize()) }
     }
 }
 
-impl<K, S> Rodeo<K, S> {
+impl<K, V: ?Sized, S> Rodeo<K, V, S> {
     /// Gets the number of interned strings
     ///
     /// # Example
@@ -694,13 +693,13 @@ impl<K, S> Rodeo<K, S> {
 
     /// Returns an iterator over the interned strings and their key values
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn iter(&self) -> Iter<'_, K> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         Iter::from_rodeo(self)
     }
 
     /// Returns an iterator over the interned strings
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn strings(&self) -> Strings<'_, K> {
+    pub fn strings(&self) -> Strings<'_, K, V> {
         Strings::from_rodeo(self)
     }
 
@@ -726,7 +725,7 @@ impl<K, S> Rodeo<K, S> {
     }
 }
 
-impl<K, S> Rodeo<K, S> {
+impl<K, V: ?Sized, S> Rodeo<K, V, S> {
     /// Consumes the current Rodeo, returning a [`RodeoReader`] to allow contention-free access of the interner
     /// from multiple threads
     ///
@@ -748,12 +747,13 @@ impl<K, S> Rodeo<K, S> {
     /// [`RodeoReader`]: crate::RodeoReader
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    pub fn into_reader(self) -> RodeoReader<K, S> {
+    pub fn into_reader(self) -> RodeoReader<K, V, S> {
         let Self {
             map,
             hasher,
             strings,
             arena,
+            phantom: _,
         } = self;
 
         // Safety: No other references outside of `map` and `strings` to the interned strings exist
@@ -781,7 +781,7 @@ impl<K, S> Rodeo<K, S> {
     /// [`RodeoResolver`]: crate::RodeoResolver
     #[cfg_attr(feature = "inline-more", inline)]
     #[must_use]
-    pub fn into_resolver(self) -> RodeoResolver<K> {
+    pub fn into_resolver(self) -> RodeoResolver<K, V> {
         let Rodeo { strings, arena, .. } = self;
 
         // Safety: No other references to the strings exist
@@ -793,19 +793,23 @@ impl<K, S> Rodeo<K, S> {
 ///
 /// [`Spur`]: crate::Spur
 /// [`RandomState`]: index.html#cargo-features
-impl Default for Rodeo<Spur, RandomState> {
+impl Default for Rodeo<Spur, str, RandomState>
+// where
+//     V: ?Sized + Internable,
+{
     #[cfg_attr(feature = "inline-more", inline)]
     fn default() -> Self {
         Self::new()
     }
 }
 
-unsafe impl<K: Send, S: Send> Send for Rodeo<K, S> {}
+unsafe impl<K: Send, V: ?Sized + Send, S: Send> Send for Rodeo<K, V, S> {}
 
-impl<Str, K, S> FromIterator<Str> for Rodeo<K, S>
+impl<Str, K, V, S> FromIterator<Str> for Rodeo<K, V, S>
 where
-    Str: AsRef<str>,
+    Str: AsRef<V>,
     K: Key,
+    V: ?Sized + Internable,
     S: BuildHasher + Default,
 {
     #[cfg_attr(feature = "inline-more", inline)]
@@ -821,19 +825,20 @@ where
         );
 
         for string in iter {
-            interner.get_or_intern(string.as_ref());
+            interner.get_or_intern(string);
         }
 
         interner
     }
 }
 
-impl<K, S> Index<K> for Rodeo<K, S>
+impl<K, V, S> Index<K> for Rodeo<K, V, S>
 where
     K: Key,
+    V: ?Sized + Internable,
     S: BuildHasher,
 {
-    type Output = str;
+    type Output = V;
 
     #[cfg_attr(feature = "inline-more", inline)]
     fn index(&self, idx: K) -> &Self::Output {
@@ -841,11 +846,12 @@ where
     }
 }
 
-impl<K, S, T> Extend<T> for Rodeo<K, S>
+impl<K, V, S, T> Extend<T> for Rodeo<K, V, S>
 where
     K: Key,
+    V: ?Sized + Internable,
     S: BuildHasher,
-    T: AsRef<str>,
+    T: AsRef<V>,
 {
     #[cfg_attr(feature = "inline-more", inline)]
     fn extend<I>(&mut self, iter: I)
@@ -853,14 +859,14 @@ where
         I: IntoIterator<Item = T>,
     {
         for s in iter {
-            self.get_or_intern(s.as_ref());
+            self.get_or_intern(s);
         }
     }
 }
 
-impl<'a, K: Key, S> IntoIterator for &'a Rodeo<K, S> {
-    type Item = (K, &'a str);
-    type IntoIter = Iter<'a, K>;
+impl<'a, K: Key, V: ?Sized + Internable, S> IntoIterator for &'a Rodeo<K, V, S> {
+    type Item = (K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
 
     #[cfg_attr(feature = "inline-more", inline)]
     fn into_iter(self) -> Self::IntoIter {
@@ -868,32 +874,31 @@ impl<'a, K: Key, S> IntoIterator for &'a Rodeo<K, S> {
     }
 }
 
-impl<K, S> Eq for Rodeo<K, S> {}
+impl<K, V: ?Sized + Internable, S> Eq for Rodeo<K, V, S> {}
 
-impl<K, S> PartialEq<Self> for Rodeo<K, S> {
+impl<K, V: ?Sized + Internable, S> PartialEq<Self> for Rodeo<K, V, S> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn eq(&self, other: &Self) -> bool {
         self.strings == other.strings
     }
 }
 
-impl<K, S> PartialEq<RodeoReader<K, S>> for Rodeo<K, S> {
+impl<K, V: ?Sized + Internable, S> PartialEq<RodeoReader<K, V, S>> for Rodeo<K, V, S> {
     #[cfg_attr(feature = "inline-more", inline)]
-    fn eq(&self, other: &RodeoReader<K, S>) -> bool {
+    fn eq(&self, other: &RodeoReader<K, V, S>) -> bool {
         self.strings == other.strings
     }
 }
 
-impl<K, S> PartialEq<RodeoResolver<K>> for Rodeo<K, S> {
+impl<K, V: ?Sized + Internable, S> PartialEq<RodeoResolver<K, V>> for Rodeo<K, V, S> {
     #[cfg_attr(feature = "inline-more", inline)]
-    fn eq(&self, other: &RodeoResolver<K>) -> bool {
+    fn eq(&self, other: &RodeoResolver<K, V>) -> bool {
         self.strings == other.strings
     }
 }
 
 compile! {
     if #[feature = "serialize"] {
-        use alloc::string::String;
         use core::num::NonZeroUsize;
         use serde::{
             de::{Deserialize, Deserializer},
@@ -903,25 +908,31 @@ compile! {
 }
 
 #[cfg(feature = "serialize")]
-impl<K, H> Serialize for Rodeo<K, H> {
+impl<K, V, H> Serialize for Rodeo<K, V, H>
+where
+    V: ?Sized + Internable,
+{
     #[cfg_attr(feature = "inline-more", inline)]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        // Serialize all of self as a `Vec<String>`
-        self.strings.serialize(serializer)
+        // Serialize all of self as a `Vec<Vec<u8>>`
+        self.strings.iter()
+            .map(|v| v.as_bytes())
+            .collect::<Vec<_>>()
+            .serialize(serializer)
     }
 }
 
 #[cfg(feature = "serialize")]
-impl<'de, K: Key, S: BuildHasher + Default> Deserialize<'de> for Rodeo<K, S> {
+impl<'de, K: Key, V: ?Sized + Internable, S: BuildHasher + Default> Deserialize<'de> for Rodeo<K, V, S> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let vector: Vec<String> = Vec::deserialize(deserializer)?;
+        let vector: Vec<Vec<u8>> = Vec::deserialize(deserializer)?;
         let capacity = {
             let total_bytes = vector.iter().map(|s| s.len()).sum::<usize>();
             let total_bytes =
@@ -939,7 +950,7 @@ impl<'de, K: Key, S: BuildHasher + Default> Deserialize<'de> for Rodeo<K, S> {
         for (key, string) in vector.into_iter().enumerate() {
             let allocated = unsafe {
                 arena
-                    .store_str(&string)
+                    .store_str(V::from_slice(&string))
                     .expect("failed to allocate enough memory")
             };
 
@@ -953,7 +964,7 @@ impl<'de, K: Key, S: BuildHasher + Default> Deserialize<'de> for Rodeo<K, S> {
             // Get the map's entry that the string should occupy
             let entry = map.raw_entry_mut().from_hash(hash, |key: &K| {
                 // Safety: The index given by `key` will be in bounds of the strings vector
-                let key_string: &str = unsafe { index_unchecked!(strings, key.into_usize()) };
+                let key_string: &V = unsafe { index_unchecked!(strings, key.into_usize()) };
 
                 // Compare the requested string against the key's string
                 allocated == key_string
@@ -973,7 +984,7 @@ impl<'de, K: Key, S: BuildHasher + Default> Deserialize<'de> for Rodeo<K, S> {
 
                     // Insert the key with the hash of the string that it points to, reusing the hash we made earlier
                     entry.insert_with_hasher(hash, key, (), |key| {
-                        let key_string: &str =
+                        let key_string: &V =
                             unsafe { index_unchecked!(strings, key.into_usize()) };
 
                         let mut state = hasher.build_hasher();
@@ -990,6 +1001,7 @@ impl<'de, K: Key, S: BuildHasher + Default> Deserialize<'de> for Rodeo<K, S> {
             hasher,
             strings,
             arena,
+            phantom: PhantomData,
         })
     }
 }
@@ -1032,13 +1044,13 @@ mod tests {
 
     #[test]
     fn with_hasher() {
-        let mut rodeo: Rodeo<Spur, RandomState> = Rodeo::with_hasher(RandomState::new());
+        let mut rodeo: Rodeo<Spur, str, RandomState> = Rodeo::with_hasher(RandomState::new());
         let key = rodeo.get_or_intern("Test");
         assert_eq!("Test", rodeo.resolve(&key));
 
         #[cfg(not(miri))]
         {
-            let mut rodeo: Rodeo<Spur, ahash::RandomState> =
+            let mut rodeo: Rodeo<Spur, str, ahash::RandomState> =
                 Rodeo::with_hasher(ahash::RandomState::new());
             let key = rodeo.get_or_intern("Test");
             assert_eq!("Test", rodeo.resolve(&key));
@@ -1047,7 +1059,7 @@ mod tests {
 
     #[test]
     fn with_capacity_and_hasher() {
-        let mut rodeo: Rodeo<Spur, RandomState> =
+        let mut rodeo: Rodeo<Spur, str, RandomState> =
             Rodeo::with_capacity_and_hasher(Capacity::for_strings(10), RandomState::new());
         assert_eq!(rodeo.capacity(), 10);
 
@@ -1066,7 +1078,7 @@ mod tests {
 
         #[cfg(not(miri))]
         {
-            let mut rodeo: Rodeo<Spur, ahash::RandomState> = Rodeo::with_capacity_and_hasher(
+            let mut rodeo: Rodeo<Spur, str, ahash::RandomState> = Rodeo::with_capacity_and_hasher(
                 Capacity::for_strings(10),
                 ahash::RandomState::new(),
             );
@@ -1373,7 +1385,7 @@ mod tests {
 
     #[test]
     fn with_capacity_memory_limits_and_hasher() {
-        let mut rodeo: Rodeo<Spur, RandomState> = Rodeo::with_capacity_memory_limits_and_hasher(
+        let mut rodeo: Rodeo<Spur, str, RandomState> = Rodeo::with_capacity_memory_limits_and_hasher(
             Capacity::default(),
             MemoryLimits::default(),
             RandomState::new(),


### PR DESCRIPTION
Adds a new public trait, `Internable`, which is by default implemented for `str`, `OsStr`, `Path`, and `[u8]`. This is a noticeably breaking change, due to the addition of a `V` generic on most things, as well as regressions for a couple type-inference locations.

I can add in #26 now if desired, as this seems a good time to make that change, if breaking inference anyways.

fixes #23