### PR TITLE
Update `try_get_or_intern` and `try_get_or_intern_static` to update both ThreadRodeo maps under a write lock

### DIFF
--- a/src/threaded_rodeo.rs
+++ b/src/threaded_rodeo.rs
@@ -324,8 +324,7 @@ where
 
             // Idea is that we want to insert into the strings first, as that will be used by what
             // is given from the map. We don't want the map to say that there is something in
-            // strings until there definitely is. This is more friendly than using the raw API, so
-            // I'm going to give this a shot first.
+            // strings until there definitely is.
             
             println!("Waiting to get into match");
             let key = match self.map.entry(string) {
@@ -351,6 +350,7 @@ where
                     self.strings.insert(key, string);
                     // Insert into map.
                     v.insert(key);
+                    println!("Inserted into vacant entry");
                     
                     key
                 }

--- a/src/threaded_rodeo.rs
+++ b/src/threaded_rodeo.rs
@@ -421,7 +421,7 @@ where
                 K::try_from_usize(self.key.fetch_add(1, Ordering::SeqCst))
                     .ok_or_else(|| LassoError::new(LassoErrorKind::KeySpaceExhaustion))
             };
-            
+
             let key = *self
                 .map
                 .entry(string)

--- a/src/threaded_rodeo.rs
+++ b/src/threaded_rodeo.rs
@@ -314,6 +314,7 @@ where
         T: AsRef<str>,
     {
         let string_slice = val.as_ref();
+
         if let Some(key) = self.map.get(string_slice) {
             Ok(*key)
         } else {

--- a/src/threaded_rodeo.rs
+++ b/src/threaded_rodeo.rs
@@ -324,8 +324,8 @@ where
             let mut shard = self.map.shards().get(shard_key).unwrap().write();
             // Try getting the value for the `string_slice` key. If we get `Some`, nothing to do. 
             // Just return the value, which is the key go to use to resolve the string. If we 
-            // get `None`, an entry for the string doesn't exist yet. Store string in the arena
-            // and update the maps accordingly.
+            // get `None`, an entry for the string doesn't exist yet. Store string in the arena,
+            // update the maps accordingly, and return the key.
             let key = match shard.get(string_slice) {
                 Some(v) => *v.get(),
                 None => {

--- a/src/threaded_rodeo.rs
+++ b/src/threaded_rodeo.rs
@@ -321,12 +321,12 @@ where
             // Determine which shard will have our `string_slice` key.
             let shard_key = self.map.determine_shard(self.map.hash_usize(&string_slice));
             // Grab the shard and a write lock on it.
-            let mut my_shard = self.map.shards().get(shard_key).unwrap().write();
+            let mut shard = self.map.shards().get(shard_key).unwrap().write();
             // Try getting the value for the `string_slice` key. If we get `Some`, nothing to do. 
             // Just return the value, which is the key go to use to resolve the string. If we 
             // get `None`, an entry for the string doesn't exist yet. Store string in the arena
             // and update the maps accordingly.
-            let key = match my_shard.get(string_slice) {
+            let key = match shard.get(string_slice) {
                 Some(v) => *v.get(),
                 None => {
                     // Safety: The drop impl removes all references before the arena is dropped
@@ -336,7 +336,7 @@ where
                         .ok_or_else(|| LassoError::new(LassoErrorKind::KeySpaceExhaustion))?;
                     
                     self.strings.insert(key, string);
-                    my_shard.insert(string, SharedValue::new(key));
+                    shard.insert(string, SharedValue::new(key));
 
                     key
                 }

--- a/src/threaded_rodeo.rs
+++ b/src/threaded_rodeo.rs
@@ -13,7 +13,7 @@ use core::{
     ops::Index,
     sync::atomic::{AtomicUsize, Ordering},
 };
-use dashmap::{mapref::entry::Entry, DashMap};
+use dashmap::{DashMap, mapref::entry::Entry};
 use hashbrown::{hash_map::RawEntryMut, HashMap};
 
 macro_rules! index_unchecked_mut {

--- a/src/threaded_rodeo.rs
+++ b/src/threaded_rodeo.rs
@@ -409,7 +409,7 @@ where
 
                     key
                 }
-            }
+            };
 
             Ok(key)
         }

--- a/src/threaded_rodeo.rs
+++ b/src/threaded_rodeo.rs
@@ -338,7 +338,10 @@ where
                     let key = *o.get();
                     // Can assert that we have this key in `strings`, as that would be a bug if we
                     // did not.
-                    assert!(self.strings.contains_key(&key));
+                    // 
+                    // EDIT: Maybe do not want to assert as this is doing more work then necessary,
+                    // which might slow things down a bit. Leaving uncommented for now.
+                    //assert!(self.strings.contains_key(&key));
 
                     key
 


### PR DESCRIPTION
This fixes the fact that for a short period of time, the "str to key" map has an entry that does not yet exist in the "key to str" map. This inconsistency can result in a case where `get_or_intern()` is called and then `resolve()` is called before the entry exists in the "key to str" map, causing the "Key out of bounds" panic to occur.

The `try_get_or_intern_static` update is a bit simpler since this function is already working with a static string. The `try_get_or_intern` update needs to use raw API to get the lock explicitly to work around the fact that it does not have a static string to work with until this string is inserted into the arena.