### PR TITLE
avoid breaking change in new Rust versions

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -444,7 +444,7 @@ macro_rules! index_unchecked {
         let elem: &_ = if cfg!(debug_assertions) {
             $slice[$idx]
         } else {
-            $slice.get_unchecked($idx)
+            *$slice.get_unchecked($idx)
         };
 
         elem


### PR DESCRIPTION
Your crate will unfortunately stop compiling due to changes to compiler internals in https://github.com/rust-lang/rust/pull/119989.

The affected pattern is the following
```rust
fn ret_string() -> &'static str {
    let slice = &[];
    
    let temp = if false {
        slice[0]
    } else {
        unsafe { slice.get_unchecked(0) }
        // Fixed by changing it to `*slice.get_unchecked(0)`.
        //
        // This incorrectly equates `slice[0]` of type `&?a` with
        // `slice.get_unchecked(0)` of type `&&?b` where `?a` and `?b`
        // are inference variables which are related via subtyping.
        // This previously resulting in a eager "occurs check" failure, causing
        // us to add an auto-deref step. We now stop to eagerly fail here
        // so the deref has to be added manually.
    };

    temp
}
```
for more details see https://github.com/rust-lang/rust/pull/119989#issuecomment-1912103911

I apologize for the inconvenience. 