### PR TITLE
update dashmap and hashbrown

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.61.0
+          toolchain: 1.71.0
           override: true
 
       - name: Check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,14 +10,21 @@ checksum = "56e72913c99b1f927aa7bd59a41518fdd9995f63ffc8760f211609e0241c4fb2"
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "atty"
@@ -41,6 +48,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bumpalo"
@@ -72,7 +85,7 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "textwrap",
  "unicode-width",
 ]
@@ -179,12 +192,13 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.4.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+checksum = "23fadfd577acfd4485fb258011b0fd080882ea83359b6fd41304900b94ccf487"
 dependencies = [
  "cfg-if",
- "hashbrown 0.12.3",
+ "crossbeam-utils",
+ "hashbrown",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -219,17 +233,12 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
  "serde",
 ]
 
@@ -285,7 +294,7 @@ dependencies = [
  "dashmap",
  "deepsize",
  "fxhash",
- "hashbrown 0.13.2",
+ "hashbrown",
  "lazy_static",
  "serde",
  "serde_json",
@@ -305,9 +314,9 @@ checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -358,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
@@ -370,15 +379,15 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-targets",
 ]
 
 [[package]]
@@ -411,18 +420,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.57"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -451,11 +460,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -540,9 +549,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -692,23 +701,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -717,42 +718,68 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serialize = ["serde", "hashbrown/serde"]
 
 # Provides a concurrent hashmap, enabled with the `multi-threaded` feature
 [dependencies.dashmap]
-version = "5.1.0"
+version = "6.0.0"
 features = ["raw-api"]
 optional = true
 
@@ -36,7 +36,7 @@ optional = true
 
 # Provides the hashmap that all single-threaded interners use
 [dependencies.hashbrown]
-version = "0.13.0"
+version = "0.14.0"
 features = ["raw"]
 
 # Allows {de}serialization of Spurs

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Bumped MSRV to 1.71.0
+- Updated hashbrown to 0.14.0
+- Updated dashmap to 0.6.0
+
 ## [0.7.2] - 2023-05-15
 
 ## [0.7.1] - 2023-05-15

--- a/benches/multi_threaded.rs
+++ b/benches/multi_threaded.rs
@@ -205,7 +205,7 @@ fn rodeo_ahash(c: &mut Criterion) {
     let mut group = c.benchmark_group("ThreadedRodeo 1 Thread (ahash)");
     group.throughput(Throughput::Bytes(INPUT.len() as u64));
 
-    let setup = ThreadedRodeoEmptySetup::new(AhashRandomState::default());
+    let setup = ThreadedRodeoEmptySetup::new(AhashRandomState::new());
     group.bench_function("get_or_intern (empty)", |b| {
         b.iter_batched(
             || setup.empty_rodeo(),
@@ -218,7 +218,7 @@ fn rodeo_ahash(c: &mut Criterion) {
         )
     });
 
-    let mut setup = ThreadedRodeoFilledSetup::new(AhashRandomState::default());
+    let mut setup = ThreadedRodeoFilledSetup::new(AhashRandomState::new());
     group.bench_function("get_or_intern (filled)", |b| {
         b.iter(|| {
             for &line in setup.lines() {
@@ -227,7 +227,7 @@ fn rodeo_ahash(c: &mut Criterion) {
         })
     });
 
-    let setup = ThreadedRodeoEmptySetup::new(AhashRandomState::default());
+    let setup = ThreadedRodeoEmptySetup::new(AhashRandomState::new());
     group.bench_function("try_get_or_intern (empty)", |b| {
         b.iter_batched(
             || setup.empty_rodeo(),
@@ -240,7 +240,7 @@ fn rodeo_ahash(c: &mut Criterion) {
         )
     });
 
-    let mut setup = ThreadedRodeoFilledSetup::new(AhashRandomState::default());
+    let mut setup = ThreadedRodeoFilledSetup::new(AhashRandomState::new());
     group.bench_function("try_get_or_intern (filled)", |b| {
         b.iter(|| {
             for &line in setup.lines() {
@@ -249,7 +249,7 @@ fn rodeo_ahash(c: &mut Criterion) {
         })
     });
 
-    let setup = ThreadedRodeoEmptySetup::new(AhashRandomState::default());
+    let setup = ThreadedRodeoEmptySetup::new(AhashRandomState::new());
     group.bench_function("get (empty)", |b| {
         b.iter_batched(
             || setup.empty_rodeo(),
@@ -262,7 +262,7 @@ fn rodeo_ahash(c: &mut Criterion) {
         )
     });
 
-    let setup = ThreadedRodeoFilledSetup::new(AhashRandomState::default());
+    let setup = ThreadedRodeoFilledSetup::new(AhashRandomState::new());
     group.bench_function("get (filled)", |b| {
         b.iter_batched(
             || setup.filled_rodeo(),
@@ -275,7 +275,7 @@ fn rodeo_ahash(c: &mut Criterion) {
         )
     });
 
-    let setup = ThreadedRodeoFilledSetup::new(AhashRandomState::default());
+    let setup = ThreadedRodeoFilledSetup::new(AhashRandomState::new());
     group.bench_function("resolve", |b| {
         b.iter_batched(
             || setup.filled_rodeo(),
@@ -288,7 +288,7 @@ fn rodeo_ahash(c: &mut Criterion) {
         )
     });
 
-    let setup = ThreadedRodeoFilledSetup::new(AhashRandomState::default());
+    let setup = ThreadedRodeoFilledSetup::new(AhashRandomState::new());
     group.bench_function("try_resolve", |b| {
         b.iter_batched(
             || setup.filled_rodeo(),

--- a/benches/reader.rs
+++ b/benches/reader.rs
@@ -153,7 +153,7 @@ fn reader_ahash(c: &mut Criterion) {
     let mut group = c.benchmark_group("RodeoReader 1 Thread (ahash)");
     group.throughput(Throughput::Bytes(INPUT.len() as u64));
 
-    let setup = ReaderEmptySetup::new(RandomState::default());
+    let setup = ReaderEmptySetup::new(RandomState::new());
     group.bench_function("get (empty)", |b| {
         b.iter_batched(
             || setup.empty_rodeo(),
@@ -166,7 +166,7 @@ fn reader_ahash(c: &mut Criterion) {
         )
     });
 
-    let setup = ReaderFilledSetup::new(RandomState::default());
+    let setup = ReaderFilledSetup::new(RandomState::new());
     group.bench_function("get (filled)", |b| {
         b.iter_batched(
             || setup.filled_rodeo(),
@@ -179,7 +179,7 @@ fn reader_ahash(c: &mut Criterion) {
         )
     });
 
-    let setup = ReaderFilledSetup::new(RandomState::default());
+    let setup = ReaderFilledSetup::new(RandomState::new());
     group.bench_function("resolve", |b| {
         b.iter_batched(
             || setup.filled_rodeo(),
@@ -192,7 +192,7 @@ fn reader_ahash(c: &mut Criterion) {
         )
     });
 
-    let setup = ReaderFilledSetup::new(RandomState::default());
+    let setup = ReaderFilledSetup::new(RandomState::new());
     group.bench_function("try_resolve", |b| {
         b.iter_batched(
             || setup.filled_rodeo(),
@@ -205,7 +205,7 @@ fn reader_ahash(c: &mut Criterion) {
         )
     });
 
-    let setup = ReaderFilledSetup::new(RandomState::default());
+    let setup = ReaderFilledSetup::new(RandomState::new());
     group.bench_function("resolve_unchecked", |b| {
         b.iter_batched(
             || setup.filled_rodeo(),

--- a/benches/single_threaded.rs
+++ b/benches/single_threaded.rs
@@ -127,7 +127,7 @@ fn rodeo_ahash(c: &mut Criterion) {
     let mut group = c.benchmark_group("Rodeo (ahash)");
     group.throughput(Throughput::Bytes(INPUT.len() as u64));
 
-    let setup = RodeoEmptySetup::new(RandomState::default());
+    let setup = RodeoEmptySetup::new(RandomState::new());
     group.bench_function("get_or_intern (empty)", |b| {
         b.iter_batched(
             || setup.empty_rodeo(),
@@ -140,7 +140,7 @@ fn rodeo_ahash(c: &mut Criterion) {
         )
     });
 
-    let mut setup = RodeoFilledSetup::new(RandomState::default());
+    let mut setup = RodeoFilledSetup::new(RandomState::new());
     group.bench_function("get_or_intern (filled)", |b| {
         b.iter(|| {
             for &line in setup.lines() {
@@ -149,7 +149,7 @@ fn rodeo_ahash(c: &mut Criterion) {
         })
     });
 
-    let setup = RodeoEmptySetup::new(RandomState::default());
+    let setup = RodeoEmptySetup::new(RandomState::new());
     group.bench_function("try_get_or_intern (empty)", |b| {
         b.iter_batched(
             || setup.empty_rodeo(),
@@ -162,7 +162,7 @@ fn rodeo_ahash(c: &mut Criterion) {
         )
     });
 
-    let mut setup = RodeoFilledSetup::new(RandomState::default());
+    let mut setup = RodeoFilledSetup::new(RandomState::new());
     group.bench_function("try_get_or_intern (filled)", |b| {
         b.iter(|| {
             for &line in setup.lines() {
@@ -171,7 +171,7 @@ fn rodeo_ahash(c: &mut Criterion) {
         })
     });
 
-    let setup = RodeoEmptySetup::new(RandomState::default());
+    let setup = RodeoEmptySetup::new(RandomState::new());
     group.bench_function("get (empty)", |b| {
         b.iter_batched(
             || setup.empty_rodeo(),
@@ -184,7 +184,7 @@ fn rodeo_ahash(c: &mut Criterion) {
         )
     });
 
-    let setup = RodeoFilledSetup::new(RandomState::default());
+    let setup = RodeoFilledSetup::new(RandomState::new());
     group.bench_function("get (filled)", |b| {
         b.iter_batched(
             || setup.filled_rodeo(),
@@ -197,7 +197,7 @@ fn rodeo_ahash(c: &mut Criterion) {
         )
     });
 
-    let setup = RodeoFilledSetup::new(RandomState::default());
+    let setup = RodeoFilledSetup::new(RandomState::new());
     group.bench_function("resolve", |b| {
         b.iter_batched(
             || setup.filled_rodeo(),
@@ -210,7 +210,7 @@ fn rodeo_ahash(c: &mut Criterion) {
         )
     });
 
-    let setup = RodeoFilledSetup::new(RandomState::default());
+    let setup = RodeoFilledSetup::new(RandomState::new());
     group.bench_function("try_resolve", |b| {
         b.iter_batched(
             || setup.filled_rodeo(),
@@ -223,7 +223,7 @@ fn rodeo_ahash(c: &mut Criterion) {
         )
     });
 
-    let setup = RodeoFilledSetup::new(RandomState::default());
+    let setup = RodeoFilledSetup::new(RandomState::new());
     group.bench_function("resolve_unchecked", |b| {
         b.iter_batched(
             || setup.filled_rodeo(),

--- a/src/arenas/bucket.rs
+++ b/src/arenas/bucket.rs
@@ -109,7 +109,7 @@ impl Drop for Bucket {
 
             // Deallocate all memory that the bucket allocated
             dealloc(
-                items as *mut u8,
+                items,
                 // Safety: Align will always be a non-zero power of two and the
                 //         size will not overflow when rounded up
                 Layout::from_size_align_unchecked(

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -47,7 +47,7 @@ unsafe impl Key for LargeSpur {
     /// Returns `None` if `int` is greater than `usize::MAX - 1`
     #[cfg_attr(feature = "inline-more", inline)]
     fn try_from_usize(int: usize) -> Option<Self> {
-        if int < usize::max_value() {
+        if int < usize::MAX {
             // Safety: The integer is less than the max value and then incremented by one, meaning that
             // is is impossible for a zero to inhabit the NonZeroUsize
             unsafe {
@@ -106,7 +106,7 @@ unsafe impl Key for Spur {
     /// Returns `None` if `int` is greater than `u32::MAX - 1`
     #[cfg_attr(feature = "inline-more", inline)]
     fn try_from_usize(int: usize) -> Option<Self> {
-        if int < u32::max_value() as usize {
+        if int < u32::MAX as usize {
             // Safety: The integer is less than the max value and then incremented by one, meaning that
             // is is impossible for a zero to inhabit the NonZeroU32
             unsafe {
@@ -165,7 +165,7 @@ unsafe impl Key for MiniSpur {
     /// Returns `None` if `int` is greater than `u16::MAX - 1`
     #[cfg_attr(feature = "inline-more", inline)]
     fn try_from_usize(int: usize) -> Option<Self> {
-        if int < u16::max_value() as usize {
+        if int < u16::MAX as usize {
             // Safety: The integer is less than the max value and then incremented by one, meaning that
             // is is impossible for a zero to inhabit the NonZeroU16
             unsafe {
@@ -224,7 +224,7 @@ unsafe impl Key for MicroSpur {
     /// Returns `None` if `int` is greater than `u8::MAX - 1`
     #[cfg_attr(feature = "inline-more", inline)]
     fn try_from_usize(int: usize) -> Option<Self> {
-        if int < u8::max_value() as usize {
+        if int < u8::MAX as usize {
             // Safety: The integer is less than the max value and then incremented by one, meaning that
             // is is impossible for a zero to inhabit the NonZeroU8
             unsafe {
@@ -402,93 +402,93 @@ mod tests {
     #[test]
     fn large() {
         let zero = LargeSpur::try_from_usize(0).unwrap();
-        let max = LargeSpur::try_from_usize(usize::max_value() - 1).unwrap();
+        let max = LargeSpur::try_from_usize(usize::MAX - 1).unwrap();
         let default = LargeSpur::default();
 
         assert_eq!(zero.into_usize(), 0);
-        assert_eq!(max.into_usize(), usize::max_value() - 1);
+        assert_eq!(max.into_usize(), usize::MAX - 1);
         assert_eq!(default.into_usize(), 0);
     }
 
     #[test]
     fn large_max_returns_none() {
-        assert_eq!(None, LargeSpur::try_from_usize(usize::max_value()));
+        assert_eq!(None, LargeSpur::try_from_usize(usize::MAX));
     }
 
     #[test]
     #[should_panic]
     #[cfg(not(miri))]
     fn large_max_panics() {
-        LargeSpur::try_from_usize(usize::max_value()).unwrap();
+        LargeSpur::try_from_usize(usize::MAX).unwrap();
     }
 
     #[test]
     fn spur() {
         let zero = Spur::try_from_usize(0).unwrap();
-        let max = Spur::try_from_usize(u32::max_value() as usize - 1).unwrap();
+        let max = Spur::try_from_usize(u32::MAX as usize - 1).unwrap();
         let default = Spur::default();
 
         assert_eq!(zero.into_usize(), 0);
-        assert_eq!(max.into_usize(), u32::max_value() as usize - 1);
+        assert_eq!(max.into_usize(), u32::MAX as usize - 1);
         assert_eq!(default.into_usize(), 0);
     }
 
     #[test]
     fn spur_returns_none() {
-        assert_eq!(None, Spur::try_from_usize(u32::max_value() as usize));
+        assert_eq!(None, Spur::try_from_usize(u32::MAX as usize));
     }
 
     #[test]
     #[should_panic]
     #[cfg(not(miri))]
     fn spur_panics() {
-        Spur::try_from_usize(u32::max_value() as usize).unwrap();
+        Spur::try_from_usize(u32::MAX as usize).unwrap();
     }
 
     #[test]
     fn mini() {
         let zero = MiniSpur::try_from_usize(0).unwrap();
-        let max = MiniSpur::try_from_usize(u16::max_value() as usize - 1).unwrap();
+        let max = MiniSpur::try_from_usize(u16::MAX as usize - 1).unwrap();
         let default = MiniSpur::default();
 
         assert_eq!(zero.into_usize(), 0);
-        assert_eq!(max.into_usize(), u16::max_value() as usize - 1);
+        assert_eq!(max.into_usize(), u16::MAX as usize - 1);
         assert_eq!(default.into_usize(), 0);
     }
 
     #[test]
     fn mini_returns_none() {
-        assert_eq!(None, MiniSpur::try_from_usize(u16::max_value() as usize));
+        assert_eq!(None, MiniSpur::try_from_usize(u16::MAX as usize));
     }
 
     #[test]
     #[should_panic]
     #[cfg(not(miri))]
     fn mini_panics() {
-        MiniSpur::try_from_usize(u16::max_value() as usize).unwrap();
+        MiniSpur::try_from_usize(u16::MAX as usize).unwrap();
     }
 
     #[test]
     fn micro() {
         let zero = MicroSpur::try_from_usize(0).unwrap();
-        let max = MicroSpur::try_from_usize(u8::max_value() as usize - 1).unwrap();
+        let max = MicroSpur::try_from_usize(u8::MAX as usize - 1).unwrap();
         let default = MicroSpur::default();
 
         assert_eq!(zero.into_usize(), 0);
-        assert_eq!(max.into_usize(), u8::max_value() as usize - 1);
+        assert_eq!(max.into_usize(), u8::MAX as usize - 1);
         assert_eq!(default.into_usize(), 0);
     }
 
     #[test]
     fn micro_returns_none() {
-        assert_eq!(None, MicroSpur::try_from_usize(u8::max_value() as usize));
+        assert_eq!(None, MicroSpur::try_from_usize(u8::MAX as usize));
     }
 
     #[test]
     #[should_panic]
     #[cfg(not(miri))]
     fn micro_panics() {
-        MicroSpur::try_from_usize(u8::max_value() as usize).unwrap();
+        MicroSpur::try_from_usize(u8::MAX as usize).unwrap();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -469,15 +469,4 @@ mod hasher {
     }
 }
 
-#[doc(hidden)]
-mod locks {
-    compile! {
-        if #[feature = "no-std"] {
-            pub use alloc::sync::Arc;
-        } else {
-            pub use std::sync::Arc;
-        }
-    }
-}
-
 // TODO: No-alloc interner

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -737,8 +737,9 @@ mod tests {
 
     #[cfg(all(not(any(miri, feature = "no-std")), feature = "multi-threaded"))]
     mod multi_threaded {
-        use crate::{locks::Arc, Key, RodeoReader, Spur, ThreadedRodeo};
+        use crate::{Key, RodeoReader, Spur, ThreadedRodeo};
         use std::thread;
+        use std::sync::Arc;
 
         #[test]
         fn get() {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -7,10 +7,7 @@ use crate::{
     Rodeo,
 };
 use alloc::vec::Vec;
-use core::{
-    hash::{BuildHasher, Hash, Hasher},
-    ops::Index,
-};
+use core::{hash::BuildHasher, ops::Index};
 use hashbrown::HashMap;
 
 /// A read-only view of a [`Rodeo`] or [`ThreadedRodeo`] that allows contention-free access to interned strings,
@@ -80,12 +77,7 @@ impl<K, S> RodeoReader<K, S> {
         let string_slice: &str = val.as_ref();
 
         // Make a hash of the requested string
-        let hash = {
-            let mut state = self.hasher.build_hasher();
-            string_slice.hash(&mut state);
-
-            state.finish()
-        };
+        let hash = self.hasher.hash_one(string_slice);
 
         // Get the map's entry that the string should occupy
         let entry = self.map.raw_entry().from_hash(hash, |key| {
@@ -752,7 +744,7 @@ mod tests {
         }
     }
 
-    #[cfg(all(not(any(miri, feature = "no-std")), features = "multi-threaded"))]
+    #[cfg(all(not(any(miri, feature = "no-std")), feature = "multi-threaded"))]
     mod multi_threaded {
         use crate::{locks::Arc, RodeoReader, ThreadedRodeo};
         use std::thread;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -561,8 +561,9 @@ mod tests {
 
     #[cfg(all(not(any(miri, feature = "no-std")), feature = "multi-threaded"))]
     mod multi_threaded {
-        use crate::{locks::Arc, Key, Spur, ThreadedRodeo};
+        use crate::{Key, Spur, ThreadedRodeo};
         use std::thread;
+        use std::sync::Arc;
 
         #[test]
         fn resolve() {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -559,7 +559,7 @@ mod tests {
         }
     }
 
-    #[cfg(all(not(any(miri, feature = "no-std")), features = "multi-threaded"))]
+    #[cfg(all(not(any(miri, feature = "no-std")), feature = "multi-threaded"))]
     mod multi_threaded {
         use crate::{locks::Arc, ThreadedRodeo};
         use std::thread;

--- a/src/rodeo.rs
+++ b/src/rodeo.rs
@@ -1042,7 +1042,7 @@ where
             .map_err(|_| LassoError::new(LassoErrorKind::FailedAllocation))?;
 
         self.map
-            .raw_table()
+            .raw_table_mut()
             .try_reserve(source.map.len(), |_| {
                 unreachable!("the target Rodeo's map should be empty while resizing");
             })

--- a/src/rodeo.rs
+++ b/src/rodeo.rs
@@ -1102,12 +1102,7 @@ impl<'de, K: Key, S: BuildHasher + Default> Deserialize<'de> for Rodeo<K, S> {
                     .expect("failed to allocate enough memory")
             };
 
-            let hash = {
-                let mut state = hasher.build_hasher();
-                allocated.hash(&mut state);
-
-                state.finish()
-            };
+            let hash = hasher.hash_one(allocated);
 
             // Get the map's entry that the string should occupy
             let entry = map.raw_entry_mut().from_hash(hash, |key: &K| {
@@ -1135,10 +1130,7 @@ impl<'de, K: Key, S: BuildHasher + Default> Deserialize<'de> for Rodeo<K, S> {
                         let key_string: &str =
                             unsafe { index_unchecked!(strings, key.into_usize()) };
 
-                        let mut state = hasher.build_hasher();
-                        key_string.hash(&mut state);
-
-                        state.finish()
+                        hasher.hash_one(key_string)
                     });
                 }
             }

--- a/src/util.rs
+++ b/src/util.rs
@@ -444,7 +444,7 @@ macro_rules! index_unchecked {
         let elem: &_ = if cfg!(debug_assertions) {
             $slice[$idx]
         } else {
-            $slice.get_unchecked($idx)
+            *$slice.get_unchecked($idx)
         };
 
         elem

--- a/src/util.rs
+++ b/src/util.rs
@@ -188,7 +188,7 @@ impl Default for MemoryLimits {
     #[cfg_attr(feature = "inline-more", inline)]
     fn default() -> Self {
         Self {
-            max_memory_usage: usize::max_value(),
+            max_memory_usage: usize::MAX,
         }
     }
 }


### PR DESCRIPTION
Performance improved drastically for me on my M2 for the ThreadedRodeo.

Main changes:
1. Update hashbrown. The only change this caused is replacing `raw_table()` with `raw_table_mut()`.
2. Update dashmap.
    * The raw-api of dashmap changed considerable. It now uses RawTable instead of HashMap to avoid double hashing.
3. Several lint fixes
    i. `max_value()` -> `MAX`.
    ii. Use the `hash_one` api stabalised in 1.71.0
4. Fix multi-threaded tests that were never enabled due to bad cfg.

Also includes #45 
Fixes #46
Fixes #27